### PR TITLE
feat(operator): Add Kubernetes event sink

### DIFF
--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -52,7 +52,7 @@ spec:
                   following: - "ready": The Dragonfly instance is ready to serve requests
                   - "configuring-replication": The controller is updating the master
                   of the Dragonfly instance - "resources-created": The Dragonfly instance
-                  is initialized i.e resources are created'
+                  resources were created but not yet configured'
                 type: string
             type: object
         type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -35,6 +36,8 @@ import (
 type DragonflyReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	EventRecorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=dragonflydb.io,resources=dragonflies,verbs=get;list;watch;create;update;patch;delete
@@ -43,6 +46,7 @@ type DragonflyReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -95,6 +99,8 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			log.Error(err, "could not update the Dragonfly object")
 			return ctrl.Result{}, err
 		}
+
+		r.EventRecorder.Event(&df, corev1.EventTypeNormal, "Created", "Created resources for Dragonfly object")
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Partially fixes #7 

This PR adds a `eventRecorder` that the controller loops add
messages into. This provides a nice interface for the user to
understand what the Operator is doing on the `Dragonfly` object.

## Testing

```bash
kubectl apply -f config/samples
```

Sample Event Output:

```
Events:
  Type    Reason       Age    From                Message
  ----    ------       ----   ----                -------
  Normal  Created      5m53s  dragonfly-operator  Created resources for Dragonfly object
  Normal  Replication  5m52s  dragonfly-operator  configured replication for first time
  Normal  Replication  105s   dragonfly-operator  Updated master instance
  Normal  Replication  80s    dragonfly-operator  Configured a new replica
```
