### PR TITLE
fix(operator): Bump version and other changes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,7 +129,7 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		EventRecorder:     eventRecorder,
-		ReplicationClient: controller.NewReplicationClient(mgr.GetClient()),
+		ReplicationClient: controller.NewReplicationClient(mgr.GetClient(), ctrl.Log.WithName("replication-client")),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Health")
 		os.Exit(1)

--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -93,7 +93,7 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// Update Status
-		df.Status.Phase = PhaseResoucesCreated
+		df.Status.Phase = PhaseResourcesCreated
 		log.Info("Created resources for object")
 		if err := r.Status().Update(ctx, &df); err != nil {
 			log.Error(err, "could not update the Dragonfly object")

--- a/internal/controller/dragonfly_controller_test.go
+++ b/internal/controller/dragonfly_controller_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Dragonfly Reconciler", func() {
 			Expect(err).To(BeNil())
 
 			// Wait until Dragonfly object is marked initialized
-			waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseResoucesCreated, 2*time.Minute)
+			waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseResourcesCreated, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
 
 			// Check for service and statefulset

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -58,7 +58,7 @@ func GetDragonflyInstanceFromPod(ctx context.Context, c client.Client, pod *core
 
 	// Use InClusterConfigurer by default
 	if rClient == nil {
-		rClient = NewReplicationClient(c)
+		rClient = NewReplicationClient(c, log)
 	}
 
 	return &DragonflyInstance{

--- a/internal/controller/health_controller.go
+++ b/internal/controller/health_controller.go
@@ -89,7 +89,7 @@ func (r *HealthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// New pod with No resources.Role
 	if !ok {
 		log.Info("Replication is not configured yet")
-		if df.df.Status.Phase == PhaseResoucesCreated {
+		if df.df.Status.Phase == PhaseResourcesCreated {
 			// Make it ready
 			log.Info("Dragonfly object is only initialized. Configuring replication for the first time")
 

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	PhaseResoucesCreated string = "resources-created"
+	PhaseResourcesCreated string = "resources-created"
 
 	PhaseConfiguringReplication string = "configuring-replication"
 

--- a/internal/resources/version.go
+++ b/internal/resources/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package resources
 
 const (
-	Version = "v0.17.0"
+	Version = "v1.0.0"
 )


### PR DESCRIPTION
This PR bumps the dragonfly version to be `v1.0.0` while also
fixing some other issues:
- Fix `PhaseResourcesCreated` spelling mistake
- Add retry mechanism for port-forwarding with tests
- Adds logging to the replication client
