### PR TITLE
feat(operator): bump dragonfly version to `v1.1.1`

### DIFF
--- a/internal/resources/version.go
+++ b/internal/resources/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package resources
 
 const (
-	Version = "v1.0.0"
+	Version = "v1.1.1"
 )


### PR DESCRIPTION
`v1.1.1` involves various fixes around replication, etc that
we want to  use and its a official release.
