### PR TITLE
feat(df_controller): do not wait for statefulset readiness

### DIFF
--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	dfv1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
 	"github.com/dragonflydb/dragonfly-operator/internal/resources"
@@ -65,7 +64,6 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	log.Info("Reconciling Dragonfly object")
-	// Ignore if resource is already created
 	if df.Status.Phase == "" {
 		log.Info("Creating resources")
 		resources, err := resources.GetDragonflyResources(ctx, &df)
@@ -80,13 +78,6 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				log.Error(err, fmt.Sprintf("could not create resource %s/%s/%s", resource.GetObjectKind(), resource.GetNamespace(), resource.GetName()))
 				return ctrl.Result{}, err
 			}
-		}
-
-		log.Info("Waiting for the statefulset to be ready")
-		// TODO: What happens if we timed out here and got the same instance event again
-		if err := waitForStatefulSetReady(ctx, r.Client, df.Name, df.Namespace, 5*time.Minute); err != nil {
-			log.Error(err, "could not wait for statefulset to be ready")
-			return ctrl.Result{}, err
 		}
 
 		// Update Status
@@ -113,12 +104,6 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				log.Error(err, fmt.Sprintf("could not update resource %s/%s/%s", resource.GetObjectKind(), resource.GetNamespace(), resource.GetName()))
 				return ctrl.Result{}, err
 			}
-		}
-
-		log.Info("Waiting for the statefulset to be ready")
-		if err := waitForStatefulSetReady(ctx, r.Client, df.Name, df.Namespace, 2*time.Minute); err != nil {
-			log.Error(err, "could not wait for statefulset to be ready")
-			return ctrl.Result{}, err
 		}
 
 		log.Info("Updated resources for object")


### PR DESCRIPTION
Fixes #27 

currently, Before the dragonfly_controller marks a DF cr as
`resources-created`, It waits until the statefulset ready which
makes no sense as the pod_lifecycle_controller listens only
for pod events. Considering, How kubernetes works i.e it reconciles
eventually, we can't expect statefulset to be ready immediately causing
errors.
