### PR TITLE
fix(df_instance): error out when can't find a master pod

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -101,6 +101,11 @@ func (dfi *DragonflyInstance) configureReplication(ctx context.Context) error {
 		}
 	}
 
+	if master == "" {
+		dfi.log.Info("Couldn't find a healthy pod to configure as master")
+		return errors.New("couldn't find a healthy pod to configure as master")
+	}
+
 	// Mark others as replicas
 	for _, pod := range pods.Items {
 		// only mark the running non-master pods


### PR DESCRIPTION
When the master pod is not found, the controller should error out
instead of moving forward and causing other errors.
