### PR TITLE
feat(CI): Allow operator image publish on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,25 @@ jobs:
           make deploy
           make test
 
+  release-operator:
+    runs-on: ubuntu-latest
+    needs: build-operator
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    env:
+      IMG: ghcr.io/dragonflydb/operator:${{ github.ref_name }}
+      VERSION: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Build
+        run: |
+          # set go version variable
+          make build
+          make docker-build
+
       - name: Publish image into GHCR
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -49,3 +66,17 @@ jobs:
           DOCKER_BUILDKIT: 1
           DOCKER_USERNAME: ${{ github.actor }}
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: publish github release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./bin/dragonfly-operator
+            LICENSE
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body: |
+            Release ${{ github.ref_name }}
+
+            Docker image: ghcr.io/dragonflydb/operator:${{ github.ref_name }}
+          draft: true

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.0
 
+VERSION ?= $(shell git describe --tags --always --dirty)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -62,7 +64,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -o bin/dragonfly-operator -ldflags "-X main.version=$(VERSION)" cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,13 +38,17 @@ import (
 
 	dragonflydbiov1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
 	"github.com/dragonflydb/dragonfly-operator/internal/controller"
-	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	//+kubebuilder:scaffold:imports
 )
 
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+)
+
+const (
+	// Version is the version of the operator.
+	Version = "source"
 )
 
 func init() {
@@ -73,7 +77,7 @@ func main() {
 	flag.Parse()
 
 	if versionFlag {
-		fmt.Println(resources.Version)
+		fmt.Println(Version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Fixes #9 

This PR adds a new step to the CI workflow that will publish the
operator into Github Packages when a version tag is pushed to Github.
This allows us to automatically release docker images that can be used
by users. This images will be made public.
