### PR TITLE
fix(ci): Login before pushing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,16 @@ jobs:
 
       - name: Build
         run: |
-          # set go version variable
           make build
-          make docker-build
 
-      - name: Publish image into GHCR
+      - name: Login to Github container repository
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Publish image into GHCR
         uses: docker/build-push-action@v2
         with:
           context: .


### PR DESCRIPTION
Looks like it is necessary to login before pushing to ghcr.io.
