### PR TITLE
fix(readme): Add steps to connect to Dragonfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ kubectl describe dragonflies.dragonflydb.io dragonfly-sample
 
 A service of the form `<dragonfly-name>.<namespace>.svc.cluster.local` will be created, that selects the master instance. You can use this service to connect to the cluster. As pods are added/removed, the service will automatically update to point to the new master.
 
+#### Connecting with `redis-cli`
+
+To connect to the cluster using `redis-cli`, you can run:
+
+```sh
+kubectl run -it --rm --restart=Never redis-cli --image=redis:7.0.10 -- redis-cli -h dragonfly-sample.default
+```
+
+This will create a temporary pod that runs `redis-cli` and connects to the cluster. After pressing `shift + R`, You can then run Redis commands as
+usual. For example, to set a key and get it back, you can run
+
+```sh
+If you don't see a command prompt, try pressing enter.
+dragonfly-sample.default:6379> GET 1
+(nil)
+dragonfly-sample.default:6379> SET 1 2
+OK
+dragonfly-sample.default:6379> GET 1
+"2"
+dragonfly-sample.default:6379> exit
+pod "redis-cli" deleted
+```
+
 ### Scaling up/down the number of replicas
 
 To scale up/down the number of replicas, you can edit the `spec.replicas` field in the Dragonfly instance. For example, to scale up to 5 replicas, you can run


### PR DESCRIPTION
This commit adds steps to connect to Dragonfly using redis-cli through
the service created by the operator.
