### PR TITLE
feat(resources): don't set default resource requirements

### DIFF
--- a/internal/resources/const.go
+++ b/internal/resources/const.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package resources
 
-import "k8s.io/apimachinery/pkg/api/resource"
-
 const (
 	// DragonflyPort is the port on which Dragonfly listens
 	DragonflyPort = 6379
@@ -59,19 +57,4 @@ const (
 	Master string = "master"
 
 	Replica string = "replica"
-)
-
-var (
-	// Default resource requirements for the Dragonfly instance
-	// resourceRequestCPU is the CPU request for the Dragonfly instance
-	resourceRequestCPU = resource.MustParse("100m")
-
-	// resourcesRequestMemory is the memory request for the Dragonfly instance
-	resourceRequestMemory = resource.MustParse("128Mi")
-
-	// resourcesLimitCPU is the CPU limit for the Dragonfly instance
-	resourceLimitCPU = resource.MustParse("1000m")
-
-	// resourcesLimitMemory is the memory limit for the Dragonfly instance
-	resourceLimitMemory = resource.MustParse("1024Mi")
 )

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -41,19 +41,6 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 		image = fmt.Sprintf("%s:%s", DragonflyImage, Version)
 	}
 
-	if df.Spec.Resources == nil {
-		df.Spec.Resources = &corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resourceLimitCPU,
-				corev1.ResourceMemory: resourceLimitMemory,
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resourceRequestCPU,
-				corev1.ResourceMemory: resourceRequestMemory,
-			},
-		}
-	}
-
 	// Create a StatefulSet, Headless Service
 	statefulset := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -141,12 +128,16 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 								TimeoutSeconds:      5,
 							},
 							ImagePullPolicy: corev1.PullAlways,
-							Resources:       *df.Spec.Resources,
 						},
 					},
 				},
 			},
 		},
+	}
+
+	// set only if resources are specified
+	if df.Spec.Resources != nil {
+		statefulset.Spec.Template.Spec.Containers[0].Resources = *df.Spec.Resources
 	}
 
 	resources = append(resources, &statefulset)


### PR DESCRIPTION
This PR removes the default resource requirements from the
controller. This is to allow the controller to be deployed in
environments where the default resource requirements are not
appropriate. Users can still set resource requirements for the resource
as per they need.
