### PR TITLE
fix(tests): move to a separate folder

### DIFF
--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package e2e
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 
 	dragonflydbiov1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
 	resourcesv1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
+	"github.com/dragonflydb/dragonfly-operator/internal/controller"
 	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -67,7 +68,7 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// Wait until Dragonfly object is marked initialized
-			waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseResourcesCreated, 2*time.Minute)
+			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseResourcesCreated, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
 
 			// Check for service and statefulset
@@ -119,7 +120,7 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// Wait until Dragonfly object is marked resources-created
-			waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseReady, 2*time.Minute)
+			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
 
 			// Check for service and statefulset
@@ -162,7 +163,7 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// Wait until Dragonfly object is marked resources-created
-			waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseReady, 2*time.Minute)
+			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
 
 			// Check for service and statefulset
@@ -220,7 +221,7 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// Wait until Dragonfly object is marked resources-created
-			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseReady, 3*time.Minute)
+			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 3*time.Minute)
 			Expect(err).To(BeNil())
 			err = waitForStatefulSetReady(ctx, k8sClient, name, namespace, 3*time.Minute)
 			Expect(err).To(BeNil())
@@ -285,7 +286,7 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// Wait until Dragonfly object is marked resources-created
-			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseReady, 3*time.Minute)
+			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 3*time.Minute)
 			Expect(err).To(BeNil())
 			err = waitForStatefulSetReady(ctx, k8sClient, name, namespace, 3*time.Minute)
 			Expect(err).To(BeNil())

--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -42,11 +42,11 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 	resourcesReq := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("100Mi"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("200m"),
-			corev1.ResourceMemory: resource.MustParse("200Mi"),
+			corev1.ResourceMemory: resource.MustParse("400Mi"),
 		},
 	}
 

--- a/e2e/dragonfly_pod_lifecycle_controller_test.go
+++ b/e2e/dragonfly_pod_lifecycle_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package e2e
 
 import (
 	"context"
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	dfv1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
+	"github.com/dragonflydb/dragonfly-operator/internal/controller"
 	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,7 +60,7 @@ var _ = Describe("DF Pod Lifecycle Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// Wait until Dragonfly object is marked initialized
-			waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseResourcesCreated, 2*time.Minute)
+			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseResourcesCreated, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
 
 			// Check for service and statefulset
@@ -80,7 +81,7 @@ var _ = Describe("DF Pod Lifecycle Reconciler", Ordered, func() {
 			err = waitForStatefulSetReady(ctx, k8sClient, name, namespace, 1*time.Minute)
 			Expect(err).To(BeNil())
 
-			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseReady, 1*time.Minute)
+			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 1*time.Minute)
 			Expect(err).To(BeNil())
 
 			// Check if there are relevant pods with expected roles
@@ -127,7 +128,7 @@ var _ = Describe("DF Pod Lifecycle Reconciler", Ordered, func() {
 			err = waitForStatefulSetReady(ctx, k8sClient, name, namespace, 1*time.Minute)
 			Expect(err).To(BeNil())
 
-			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseReady, 1*time.Minute)
+			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 1*time.Minute)
 			Expect(err).To(BeNil())
 
 			// Check if there are relevant pods with expected roles
@@ -173,7 +174,7 @@ var _ = Describe("DF Pod Lifecycle Reconciler", Ordered, func() {
 
 			// Expect a new replica
 			// Wait for Status to be ready
-			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, PhaseReady, 1*time.Minute)
+			err = waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 1*time.Minute)
 			Expect(err).To(BeNil())
 			err = waitForStatefulSetReady(ctx, k8sClient, name, namespace, 1*time.Minute)
 			Expect(err).To(BeNil())

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package e2e
 
 import (
 	"path/filepath"

--- a/e2e/util.go
+++ b/e2e/util.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 DragonflyDB authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func waitForStatefulSetReady(ctx context.Context, c client.Client, name, namespace string, maxDuration time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, maxDuration)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for statefulset to be ready")
+		default:
+			// Check if the statefulset is ready
+			ready, err := isStatefulSetReady(ctx, c, name, namespace)
+			if err != nil {
+				return err
+			}
+			if ready {
+				return nil
+			}
+		}
+	}
+}
+
+func isStatefulSetReady(ctx context.Context, c client.Client, name, namespace string) (bool, error) {
+	var statefulSet appsv1.StatefulSet
+	if err := c.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, &statefulSet); err != nil {
+		return false, nil
+	}
+
+	if statefulSet.Status.ReadyReplicas == *statefulSet.Spec.Replicas {
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
As these tests are more e2e than unit, Its best to move them
into a separate folder so that the difference is obivous and unit
tests can be added separately
