### PR TITLE
fix(dfi): check pod ip before marking

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -270,8 +270,7 @@ func (dfi *DragonflyInstance) checkAndConfigureReplication(ctx context.Context) 
 
 		// configure non replica pods as replicas
 		for _, pod := range pods.Items {
-			if pod.Labels[resources.Role] != resources.Replica && pod.Labels[resources.Role] != resources.Master {
-				dfi.log.Info("configuring pod as replica", "pod", pod.Name)
+			if pod.Labels[resources.Role] == "" {
 				if err := dfi.configureReplica(ctx, &pod); err != nil {
 					return err
 				}

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -271,8 +271,10 @@ func (dfi *DragonflyInstance) checkAndConfigureReplication(ctx context.Context) 
 		// configure non replica pods as replicas
 		for _, pod := range pods.Items {
 			if pod.Labels[resources.Role] == "" {
-				if err := dfi.configureReplica(ctx, &pod); err != nil {
-					return err
+				if pod.Status.Phase == corev1.PodRunning && pod.Status.ContainerStatuses[0].Ready && pod.Status.PodIP != "" {
+					if err := dfi.configureReplica(ctx, &pod); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -57,9 +57,9 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Pod is not ready to be processed yet
-	if pod.Status.PodIP == "" {
-		log.Info("Pod IP is not yet available")
+	// check for pod readiness
+	if pod.Status.PodIP == "" || pod.Status.Phase != corev1.PodRunning || !pod.Status.ContainerStatuses[0].Ready {
+		log.Info("Pod is not ready yet")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 


### PR DESCRIPTION
Now that we mark pods as they get instanced without waiting for all
resources to be created the code cannot expect all pods to be ready
while it configures replication. This adds an extra pod IP Check.

If there is a pod without IP, the controller will wait for the next
pod event which gets triggered automatically once Kubernetes adds the
IP.
