### PR TITLE
fix(dragonfly): check pod status before marking replica

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -253,10 +253,11 @@ func (dfi *DragonflyInstance) checkAndConfigureReplication(ctx context.Context) 
 
 		// configure non replica pods as replicas
 		for _, pod := range pods.Items {
-			if pod.Labels[resources.Role] != resources.Replica && pod.Labels[resources.Role] != resources.Master {
-				dfi.log.Info("configuring pod as replica", "pod", pod.Name)
-				if err := dfi.configureReplica(ctx, &pod); err != nil {
-					return err
+			if pod.Labels[resources.Role] == "" {
+				if pod.Status.Phase == corev1.PodRunning && pod.Status.ContainerStatuses[0].Ready && pod.Status.PodIP != "" {
+					if err := dfi.configureReplica(ctx, &pod); err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This adds the same checks that we use everywhere else before
marking a replica as ready. This should prevent the replica
from being marked as ready before the pod is actually ready.
