### PR TITLE
fix(readme): Update manifests to use `v0.0.3`

### DIFF
--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -450,7 +450,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/dragonflydb/operator:v0.0.2
+        image: ghcr.io/dragonflydb/operator:v0.0.3
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Updates the manifests used in readme demos to use the
`v0.0.3` version of the Operator.
