### PR TITLE
fix(version): Use latest released tag `v1.2.0`

### DIFF
--- a/internal/resources/version.go
+++ b/internal/resources/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package resources
 
 const (
-	Version = "alpha-ubuntu"
+	Version = "v1.2.0"
 )


### PR DESCRIPTION
We switched to using a weekly release build with https://github.com/dragonflydb/dragonfly-operator/pull/54
to get fixes that were needed. Now, That we have a release,
Its better to use a release version.
