### PR TITLE
fix(manifests): Use `docker.dragonfly.io` as the registry

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/dragonflydb/operator
-  newTag: v0.0.2
+  newName: docker.dragonflydb.io/dragonflydb/operator
+  newTag: v0.0.3

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -450,7 +450,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/dragonflydb/operator:v0.0.3
+        image: docker.dragonflydb.io/dragonflydb/operator:v0.0.3
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This updates the README manifests to use the `docker.dragonfly.io`
registry to pull the Operator.
