### PR TITLE
feat(resources): Updated the CRD to support setting environment variables and a service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ To vertically scale the instance, you can edit the `spec.resources` field in the
 kubectl patch dragonfly dragonfly-sample --type merge -p '{"spec":{"resources":{"requests":{"memory":"1Gi"},"limits":{"memory":"2Gi"}}}}'
 ```
 
+### Configuring instance authentication
+
+To add authentication to the dragonfly pods, you either set the `DFLY_PASSWORD` environment variable, or add the `--requirepass` argument. 
+
 ### Deleting a Dragonfly instance
 
 To delete a Dragonfly instance, you can run

--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -46,6 +46,11 @@ type DragonflySpec struct {
 	// +kubebuilder:validation:Optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// (Optional) Env variables to add to the Dragonfly pods.
+	// +optional
+	// +kubebuilder:validation:Optional
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
 	// (Optional) Dragonfly container resource limits. Any container limits
 	// can be specified.
 	// +optional
@@ -61,6 +66,11 @@ type DragonflySpec struct {
 	// +optional
 	// +kubebuilder:validation:Optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// (Optional) Dragonfly pod service account name
+	// +optional
+	// +kubebuilder:validation:Optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // DragonflyStatus defines the observed state of Dragonfly

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -874,6 +874,115 @@ spec:
                 items:
                   type: string
                 type: array
+              env:
+                description: (Optional) Env variables to add to the Dragonfly pods.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 description: Image is the Dragonfly image to use
                 type: string
@@ -930,6 +1039,9 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              serviceAccountName:
+                description: (Optional) Dragonfly pod service account name
+                type: string
               tolerations:
                 description: (Optional) Dragonfly pod tolerations
                 items:

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -98,6 +98,7 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 								},
 							},
 							Args: DefaultDragonflyArgs,
+							Env:  df.Spec.Env,
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
@@ -155,6 +156,10 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 
 	if df.Spec.Tolerations != nil {
 		statefulset.Spec.Template.Spec.Tolerations = df.Spec.Tolerations
+	}
+
+	if df.Spec.ServiceAccountName != "" {
+		statefulset.Spec.Template.Spec.ServiceAccountName = df.Spec.ServiceAccountName
 	}
 
 	resources = append(resources, &statefulset)


### PR DESCRIPTION
In order to get authentication working, the operator needed to be updated to communicate with the pods using their configured passwords. I also added support for setting an environment variable and service account, which allows for different methods of setting the password. I believe this satisfies some of the requests in https://github.com/dragonflydb/dragonfly-operator/issues/50

EDIT: since https://github.com/dragonflydb/dragonfly-operator/commit/4465e8082c05fafc34a3f029adba25a1ba8b4ad8, this PR does not modify how the operator communicates with pods. 