### PR TITLE
fix: use admin-port for dragonfly operations

### DIFF
--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			// check resource requirements of statefulset
 			Expect(ss.Spec.Template.Spec.Containers[0].Resources).To(Equal(*df.Spec.Resources))
 			// check args of statefulset
-			Expect(ss.Spec.Template.Spec.Containers[0].Args[1:]).To(Equal(df.Spec.Args))
+			Expect(ss.Spec.Template.Spec.Containers[0].Args[2:]).To(Equal(df.Spec.Args))
 
 			// Check if there are relevant pods with expected roles
 			var pods corev1.PodList
@@ -351,7 +351,7 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// check for pod args
-			Expect(ss.Spec.Template.Spec.Containers[0].Args[1:]).To(Equal(newArgs))
+			Expect(ss.Spec.Template.Spec.Containers[0].Args[2:]).To(Equal(newArgs))
 
 			// check for pod resources
 			Expect(ss.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU].Equal(newResources.Limits[corev1.ResourceCPU])).To(BeTrue())

--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -94,7 +94,8 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			// check resource requirements of statefulset
 			Expect(ss.Spec.Template.Spec.Containers[0].Resources).To(Equal(*df.Spec.Resources))
 			// check args of statefulset
-			Expect(ss.Spec.Template.Spec.Containers[0].Args[2:]).To(Equal(df.Spec.Args))
+			expectArgs := append(resources.DefaultDragonflyArgs, df.Spec.Args...)
+			Expect(ss.Spec.Template.Spec.Containers[0].Args).To(Equal(expectArgs))
 
 			// Check if there are relevant pods with expected roles
 			var pods corev1.PodList
@@ -351,7 +352,8 @@ var _ = Describe("Dragonfly Reconciler", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			// check for pod args
-			Expect(ss.Spec.Template.Spec.Containers[0].Args[2:]).To(Equal(newArgs))
+			expectedArgs := append(resources.DefaultDragonflyArgs, newArgs...)
+			Expect(ss.Spec.Template.Spec.Containers[0].Args).To(Equal(expectedArgs))
 
 			// check for pod resources
 			Expect(ss.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU].Equal(newResources.Limits[corev1.ResourceCPU])).To(BeTrue())

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	"github.com/go-redis/redis"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -98,7 +99,7 @@ func isStableState(ctx context.Context, c client.Client, pod *corev1.Pod) (bool,
 	}
 
 	redisClient := redis.NewClient(&redis.Options{
-		Addr: fmt.Sprintf("%s:%d", pod.Status.PodIP, 6379),
+		Addr: fmt.Sprintf("%s:%d", pod.Status.PodIP, resources.DragonflyAdminPort),
 	})
 
 	_, err := redisClient.Ping().Result()

--- a/internal/resources/const.go
+++ b/internal/resources/const.go
@@ -21,6 +21,7 @@ const (
 	DragonflyPort = 6379
 
 	// DragonflyAdminPort is the admin port on which Dragonfly listens
+	// IMPORTANT: This port should not be opened to non trusted networks.
 	DragonflyAdminPort = 9999
 
 	// DragonflyPortName is the name of the port on which the Dragonfly instance listens

--- a/internal/resources/const.go
+++ b/internal/resources/const.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package resources
 
+import "fmt"
+
 const (
 	// DragonflyPort is the port on which Dragonfly listens
 	DragonflyPort = 6379
@@ -62,3 +64,8 @@ const (
 
 	Replica string = "replica"
 )
+
+var DefaultDragonflyArgs = []string{
+	"--alsologtostderr",
+	fmt.Sprintf("-admin_port=%d", DragonflyAdminPort),
+}

--- a/internal/resources/const.go
+++ b/internal/resources/const.go
@@ -20,6 +20,9 @@ const (
 	// DragonflyPort is the port on which Dragonfly listens
 	DragonflyPort = 6379
 
+	// DragonflyAdminPort is the admin port on which Dragonfly listens
+	DragonflyAdminPort = 9999
+
 	// DragonflyPortName is the name of the port on which the Dragonfly instance listens
 	DragonflyPortName = "redis"
 

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -97,10 +97,7 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 									ContainerPort: DragonflyPort,
 								},
 							},
-							Args: []string{
-								"--alsologtostderr",
-								fmt.Sprintf("-admin_port=%d", DragonflyAdminPort),
-							},
+							Args: DefaultDragonflyArgs,
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -99,6 +99,7 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 							},
 							Args: []string{
 								"--alsologtostderr",
+								fmt.Sprintf("-admin_port=%d", DragonflyAdminPort),
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
Dragonfly operator should use admin port to manage operations on TLS or password enabled dragonfly instances.