### PR TITLE
feat(upgrade): Use repltakeover

### DIFF
--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -191,10 +191,6 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			stopChan := make(chan struct{}, 1)
 			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, password)
 			Expect(err).To(BeNil())
-
-			// Insert test data
-			Expect(rc.Set(ctx, "foo", "bar", 0).Err()).To(BeNil())
-
 			defer close(stopChan)
 
 			// insert test data
@@ -494,18 +490,6 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			Expect(err).To(BeNil())
 			Expect(data).To(Equal("bar"))
 			defer close(stopChan)
-		})
-
-		It("Check for data", func() {
-			stopChan := make(chan struct{}, 1)
-			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, password)
-			Expect(err).To(BeNil())
-			defer close(stopChan)
-
-			// check if the Data exists
-			data, err := rc.Get(ctx, "foo").Result()
-			Expect(err).To(BeNil())
-			Expect(data).To(Equal("bar"))
 		})
 
 		It("Cleanup", func() {

--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 
 		})
 
-		It("Check for connectivity", func() {
+		It("Check for connectivity and insert data", func() {
 			stopChan := make(chan struct{}, 1)
 			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, password)
 			Expect(err).To(BeNil())
@@ -196,6 +196,9 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			Expect(rc.Set(ctx, "foo", "bar", 0).Err()).To(BeNil())
 
 			defer close(stopChan)
+
+			// insert test data
+			Expect(rc.Set(ctx, "foo", "bar", 0).Err()).To(BeNil())
 		})
 
 		It("Increase in replicas should be propagated successfully", func() {
@@ -491,6 +494,18 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			Expect(err).To(BeNil())
 			Expect(data).To(Equal("bar"))
 			defer close(stopChan)
+		})
+
+		It("Check for data", func() {
+			stopChan := make(chan struct{}, 1)
+			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, password)
+			Expect(err).To(BeNil())
+			defer close(stopChan)
+
+			// check if the Data exists
+			data, err := rc.Get(ctx, "foo").Result()
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal("bar"))
 		})
 
 		It("Cleanup", func() {

--- a/e2e/util.go
+++ b/e2e/util.go
@@ -99,7 +99,7 @@ func checkAndK8sPortForwardRedis(ctx context.Context, clientset *kubernetes.Clie
 		return nil, fmt.Errorf("no master pod found")
 	}
 
-	fw, err := portForward(ctx, clientset, config, master, stopChan, resources.DragonflyAdminPort)
+	fw, err := portForward(ctx, clientset, config, master, stopChan, resources.DragonflyPort)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/util.go
+++ b/e2e/util.go
@@ -105,7 +105,7 @@ func checkAndK8sPortForwardRedis(ctx context.Context, clientset *kubernetes.Clie
 	}
 
 	redisOptions := &redis.Options{
-		Addr: fmt.Sprintf("localhost:9998"),
+		Addr: fmt.Sprintf("localhost:%d", resources.DragonflyPort),
 	}
 
 	if password != "" {
@@ -148,7 +148,7 @@ func portForward(ctx context.Context, clientset *kubernetes.Clientset, config *r
 	}
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
-	ports := []string{fmt.Sprintf("%d:%d", 9998, resources.DragonflyPort)}
+	ports := []string{fmt.Sprintf("%d:%d", port, resources.DragonflyPort)}
 	readyChan := make(chan struct{}, 1)
 
 	fw, err := portforward.New(dialer, ports, stopChan, readyChan, io.Discard, os.Stderr)

--- a/hack/print-roles.go
+++ b/hack/print-roles.go
@@ -68,7 +68,7 @@ func main() {
 			panic(err.Error())
 		}
 
-		fmt.Printf("%s, %s: %s\n", pod.Name, pod.Status.PodIP, role)
+		fmt.Printf("%s, %s, %s: %s\n", pod.Name, pod.Status.PodIP, pod.Labels["role"], role)
 	}
 }
 
@@ -87,7 +87,7 @@ func portForward(ctx context.Context, clientset *kubernetes.Clientset, config *r
 	}
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
-	ports := []string{fmt.Sprintf("%d:%d", port, 6379)}
+	ports := []string{fmt.Sprintf("%d:%d", port, 9999)}
 	readyChan := make(chan struct{}, 1)
 	stopChan := make(chan struct{}, 1)
 

--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -265,32 +265,9 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		log.Info("Updated resources for object")
-
-		// perform a rollout only if the pod spec has changed
-		if err := r.Get(ctx, client.ObjectKey{Namespace: df.Namespace, Name: df.Name}, &statefulSet); err != nil {
-			log.Error(err, "could not get statefulset")
-			return ctrl.Result{}, err
-		}
-
-		// Check if the pod spec has changed
-		if statefulSet.Status.UpdatedReplicas != statefulSet.Status.Replicas {
-			log.Info("Pod spec has changed, performing a rollout")
-			r.EventRecorder.Event(&df, corev1.EventTypeNormal, "Rollout", "Starting a rollout")
-
-			// Start rollout and update status
-			// update status so that we can track progress
-			df.Status.IsRollingUpdate = true
-			if err := r.Status().Update(ctx, &df); err != nil {
-				log.Error(err, "could not update the Dragonfly object")
-				return ctrl.Result{Requeue: true}, err
-			}
-
-			// requeue so that the rollout is processed
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
 		r.EventRecorder.Event(&df, corev1.EventTypeNormal, "Resources", "Updated resources")
+		return ctrl.Result{Requeue: true}, nil
 	}
-	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -186,6 +186,12 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 
+		latestReplica, err := getLatestReplica(ctx, r.Client, &updatedStatefulset)
+		if err != nil {
+			log.Error(err, "could not get latest replica")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
+		}
+
 		masterOnLatest, err := isPodOnLatestVersion(ctx, r.Client, &master, &updatedStatefulset)
 		if err != nil {
 			log.Error(err, "could not check if pod is on latest version")
@@ -195,13 +201,12 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// If we are here it means that all replicas
 		// are on latest version
 		if !masterOnLatest {
-			// Update Master now
-			log.Info("deleting master")
-			if err := r.Delete(ctx, &master); err != nil {
-				log.Error(err, "could not delete master")
-				return ctrl.Result{Requeue: true}, err
+			// Update master now
+			if err := replTakeover(ctx, latestReplica); err != nil {
+				log.Error(err, "could not update master")
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 			}
-			r.EventRecorder.Event(&df, corev1.EventTypeNormal, "Rollout", fmt.Sprintf("Deleting master %s", master.Name))
+			r.EventRecorder.Event(&df, corev1.EventTypeNormal, "Rollout", fmt.Sprintf("Shutting down master %s", master.Name))
 		}
 
 		// If we are here all are on latest version

--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -264,8 +264,9 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 
-		log.Info("Updated resources for object")
-		return ctrl.Result{Requeue: true}, nil
+		log.Info("Updated resources for object. Requeing")
+		r.EventRecorder.Event(&df, corev1.EventTypeNormal, "Resources", "Updated resources")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 }
 

--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -202,6 +202,7 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// are on latest version
 		if !masterOnLatest {
 			// Update master now
+			log.Info("Running REPLTAKEOVER on replica", "pod", master.Name)
 			if err := replTakeover(ctx, r.Client, latestReplica); err != nil {
 				log.Error(err, "could not update master")
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, err
@@ -209,6 +210,7 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			r.EventRecorder.Event(&df, corev1.EventTypeNormal, "Rollout", fmt.Sprintf("Shutting down master %s", master.Name))
 
 			// delete the old master, so that it gets recreated with the new version
+			log.Info("deleting master", "pod", master.Name)
 			if err := r.Delete(ctx, &master); err != nil {
 				log.Error(err, "could not delete pod")
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, err

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -94,7 +94,7 @@ func replTakeover(ctx context.Context, newMaster *corev1.Pod) error {
 		Addr: fmt.Sprintf("%s:%d", newMaster.Status.PodIP, resources.DragonflyAdminPort),
 	})
 
-	resp, err := redisClient.Do(ctx, "REPLTAKEOVER 10000").Result()
+	resp, err := redisClient.Do(ctx, "repltakeover 10000").Result()
 	if err != nil {
 		return fmt.Errorf("error running REPLTAKEOVER command: %w", err)
 	}

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -71,7 +71,7 @@ func getLatestReplica(ctx context.Context, c client.Client, statefulSet *appsv1.
 		return nil, err
 	}
 
-	// Iterate over the pods and find the one which is on the latest version
+	// Iterate over the pods and find a replica which is on the latest version
 	for _, pod := range podList.Items {
 
 		isLatest, err := isPodOnLatestVersion(ctx, c, &pod, statefulSet)

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -52,6 +53,57 @@ func isPodOnLatestVersion(ctx context.Context, c client.Client, pod *corev1.Pod,
 	}
 
 	return false, nil
+}
+
+// getLatestReplica returns a replica pod which is on the latest version
+// of the given statefulset
+func getLatestReplica(ctx context.Context, c client.Client, statefulSet *appsv1.StatefulSet) (*corev1.Pod, error) {
+	// Get the list of pods
+	podList := &corev1.PodList{}
+	err := c.List(ctx, podList, &client.ListOptions{
+		Namespace: statefulSet.Namespace,
+		LabelSelector: labels.SelectorFromValidatedSet(map[string]string{
+			"app":                              statefulSet.Name,
+			resources.KubernetesPartOfLabelKey: "dragonfly",
+		}),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over the pods and find the one which is on the latest version
+	for _, pod := range podList.Items {
+
+		isLatest, err := isPodOnLatestVersion(ctx, c, &pod, statefulSet)
+		if err != nil {
+			return nil, err
+		}
+
+		if isLatest && pod.Labels[resources.Role] == resources.Replica {
+			return &pod, nil
+		}
+	}
+
+	return nil, errors.New("no replica pod found on latest version")
+
+}
+
+// replTakeover runs the replTakeOver on the given replica pod
+func replTakeover(ctx context.Context, newMaster *corev1.Pod) error {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: fmt.Sprintf("%s:%d", newMaster.Status.PodIP, resources.DragonflyAdminPort),
+	})
+
+	resp, err := redisClient.Do(ctx, "REPLTAKEOVER 10000").Result()
+	if err != nil {
+		return fmt.Errorf("error running REPLTAKEOVER command: %w", err)
+	}
+
+	if resp != "OK" {
+		return fmt.Errorf("response of `REPLTAKEOVER` on replica is not OK: %s", resp)
+	}
+
+	return nil
 }
 
 func waitForStatefulSetReady(ctx context.Context, c client.Client, name, namespace string, maxDuration time.Duration) error {


### PR DESCRIPTION
Instead of deleting the master, This PR updates the rollout flow to run `repltakeover` on a latest replica which would mark this pod as the master while terminating the old master. When a pod is terminated, Kubernetes automatically recreates it and the pod lifecycle controller will do the needful.

The pod lifecycle controller does react on various instances and tries to corrupt, but we only expect it to handle new pod creations and hence toggle is added to not react on `isRollingUpdate=true` for other events.