### PR TITLE
fix(updates): re-run loop when update is made 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@v2.12.1
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -r -p -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO)  -vv -r -p -coverprofile cover.out
 
 ##@ Build
 

--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -326,7 +326,7 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			}, &ss)
 			Expect(err).To(BeNil())
 
-			// check for env
+			// check for image
 			Expect(ss.Spec.Template.Spec.Containers[0].Image).To(Equal(df.Spec.Image))
 
 			// Check if there are relevant pods with expected roles

--- a/e2e/util.go
+++ b/e2e/util.go
@@ -68,7 +68,7 @@ func isStatefulSetReady(ctx context.Context, c client.Client, name, namespace st
 		return false, nil
 	}
 
-	if statefulSet.Status.ReadyReplicas == *statefulSet.Spec.Replicas {
+	if statefulSet.Status.ReadyReplicas == *statefulSet.Spec.Replicas && statefulSet.Status.UpdatedReplicas == statefulSet.Status.Replicas {
 		return true, nil
 	}
 

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -120,7 +120,7 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			} else {
 				log.Info(fmt.Sprintf("Master exists. Configuring %s as replica", pod.Status.PodIP))
 				if err := dfi.configureReplica(ctx, &pod); err != nil {
-					log.Error(err, "could not mark replica from db")
+					log.Error(err, "could not mark replica from db. retrying")
 					return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 				}
 
@@ -148,7 +148,7 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		log.Info("Non-deletion event for a pod with an existing role. checking if something is wrong", "pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name), "role", role)
 
 		if err := dfi.checkAndConfigureReplication(ctx); err != nil {
-			log.Error(err, "could not check and configure replication")
+			log.Error(err, "could not check and configure replication. retrying")
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
 

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -34,8 +34,6 @@ import (
 const (
 	PhaseResourcesCreated string = "resources-created"
 
-	PhaseResourcesUpdated string = "resources-updated"
-
 	PhaseReady string = "ready"
 )
 


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/dragonfly-operator/issues/93

Currently, We sometimes miss updates when we compare the statefulset
version. This could be stale as update couldn't have propogated already.

This PR fixes that by requeuing the object when an update is made, so
that we retreive the latest version when ran again.