### PR TITLE
fix(cacert): Use `--tls_ca_cert_file` to pass the file

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -108,10 +108,9 @@ type Authentication struct {
 	PasswordFromSecret *corev1.SecretKeySelector `json:"passwordFromSecret,omitempty"`
 
 	// (Optional) If specified, the Dragonfly instance will check if the
-	// client certificate is signed by one of this CA. Server TLS must be enabled for this.
-	// Multiple CAs can be specified with various key names.
+	// client certificate is signed by this CA. Server TLS must be enabled for this.
 	// +optional
-	ClientCaCertSecret *corev1.SecretReference `json:"clientCaCertSecret,omitempty"`
+	ClientCaCertSecret *corev1.SecretKeySelector `json:"clientCaCertSecret,omitempty"`
 }
 
 // DragonflyStatus defines the observed state of Dragonfly

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -36,8 +36,8 @@ func (in *Authentication) DeepCopyInto(out *Authentication) {
 	}
 	if in.ClientCaCertSecret != nil {
 		in, out := &in.ClientCaCertSecret, &out.ClientCaCertSecret
-		*out = new(v1.SecretReference)
-		**out = **in
+		*out = new(v1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -879,18 +879,23 @@ spec:
                 properties:
                   clientCaCertSecret:
                     description: (Optional) If specified, the Dragonfly instance will
-                      check if the client certificate is signed by one of this CA.
-                      Server TLS must be enabled for this. Multiple CAs can be specified
-                      with various key names.
+                      check if the client certificate is signed by this CA. Server
+                      TLS must be enabled for this.
                     properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
                       name:
-                        description: name is unique within a namespace to reference
-                          a secret resource.
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      namespace:
-                        description: namespace defines the space within which the
-                          secret name must be unique.
-                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
                     type: object
                     x-kubernetes-map-type: atomic
                   passwordFromSecret:


### PR DESCRIPTION
So, Looks like `--tls_ca_cert_dir` has its own complexity and I think it makes sense to start with a single certificate as specifying the dir requires some processing before 