### PR TITLE
feat(resources): Add labels field to spec, which will be added to pods

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -46,6 +46,11 @@ type DragonflySpec struct {
 	// +kubebuilder:validation:Optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// (Optional) Labels to add to the Dragonfly pods.
+	// +optional
+	// +kubebuilder:validation:Optional
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// (Optional) Env variables to add to the Dragonfly pods.
 	// +optional
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -125,6 +125,13 @@ func (in *DragonflySpec) DeepCopyInto(out *DragonflySpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -1031,6 +1031,11 @@ spec:
               image:
                 description: Image is the Dragonfly image to use
                 type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: (Optional) Labels to add to the Dragonfly pods.
+                type: object
               replicas:
                 description: Replicas is the total number of Dragonfly instances including
                   the master

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -231,6 +231,13 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 		statefulset.Spec.Template.ObjectMeta.Annotations = df.Spec.Annotations
 	}
 
+	for key := range df.Spec.Labels {
+		// Make sure we do not overwrite any existing labels
+		if _, ok := statefulset.Spec.Template.ObjectMeta.Labels[key]; !ok {
+			statefulset.Spec.Template.ObjectMeta.Labels[key] = df.Spec.Labels[key]
+		}
+	}
+
 	if df.Spec.Affinity != nil {
 		statefulset.Spec.Template.Spec.Affinity = df.Spec.Affinity
 	}


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

Hey there 👋 

We wanted to add labels to the dragonfly pods which are used by some other tooling we have. Since that was not possible before, this PR adds support for that!

Please let me know if I'm missing something. One of the considerations I had is that the operator already assigns some labels to the pods/statefulset so we should not allow the user to override them (for now?).

