### PR TITLE
fix(redis-client): Close redis clients ASAP

### DIFF
--- a/hack/print-roles.go
+++ b/hack/print-roles.go
@@ -112,6 +112,7 @@ func getRole(ctx context.Context, url string) (string, error) {
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: url,
 	})
+	defer redisClient.Close()
 
 	resp, err := redisClient.Info(ctx, "replication").Result()
 	if err != nil {

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -219,6 +219,7 @@ func (dfi *DragonflyInstance) checkReplicaRole(ctx context.Context, pod *corev1.
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: fmt.Sprintf("%s:%d", pod.Status.PodIP, resources.DragonflyAdminPort),
 	})
+	defer redisClient.Close()
 
 	resp, err := redisClient.Info(ctx, "replication").Result()
 	if err != nil {
@@ -342,6 +343,7 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: fmt.Sprintf("%s:%d", pod.Status.PodIP, resources.DragonflyAdminPort),
 	})
+	defer redisClient.Close()
 
 	dfi.log.Info("Trying to invoke SLAVE OF command", "pod", pod.Name, "master", masterIp, "addr", redisClient.Options().Addr)
 	resp, err := redisClient.SlaveOf(ctx, masterIp, fmt.Sprint(resources.DragonflyAdminPort)).Result()
@@ -369,6 +371,7 @@ func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Po
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: fmt.Sprintf("%s:%d", pod.Status.PodIP, resources.DragonflyAdminPort),
 	})
+	defer redisClient.Close()
 
 	dfi.log.Info("Running SLAVE OF NO ONE command", "pod", pod.Name, "addr", redisClient.Options().Addr)
 	resp, err := redisClient.SlaveOf(ctx, "NO", "ONE").Result()

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -93,6 +93,7 @@ func replTakeover(ctx context.Context, c client.Client, newMaster *corev1.Pod) e
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: fmt.Sprintf("%s:%d", newMaster.Status.PodIP, resources.DragonflyAdminPort),
 	})
+	defer redisClient.Close()
 
 	resp, err := redisClient.Do(ctx, "repltakeover", "10000").Result()
 	if err != nil {
@@ -156,6 +157,7 @@ func isStableState(ctx context.Context, c client.Client, pod *corev1.Pod) (bool,
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: fmt.Sprintf("%s:%d", pod.Status.PodIP, resources.DragonflyAdminPort),
 	})
+	defer redisClient.Close()
 
 	_, err := redisClient.Ping(ctx).Result()
 	if err != nil {


### PR DESCRIPTION
Instead of waiting 30mins until idle connections are closed (according to go-redis docs) or until GC will handle old tcp file descriptors, it's better to close go-redis TCP connections ASAP