### PR TITLE
Add nodeSelector field to dragonfly spec, which will be added to podSpec in statefulset

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -72,6 +72,11 @@ type DragonflySpec struct {
 	// +kubebuilder:validation:Optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// (Optional) Dragonfly pod node selector
+	// +optional
+	// +kubebuilder:validation:Optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// (Optional) Dragonfly pod tolerations
 	// +optional
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -154,6 +154,13 @@ func (in *DragonflySpec) DeepCopyInto(out *DragonflySpec) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]v1.Toleration, len(*in))

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -1054,6 +1054,11 @@ spec:
                   type: string
                 description: (Optional) Labels to add to the Dragonfly pods.
                 type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: (Optional) Dragonfly pod node selector
+                type: object
               replicas:
                 description: Replicas is the total number of Dragonfly instances including
                   the master

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -267,6 +267,10 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 		statefulset.Spec.Template.Spec.Affinity = df.Spec.Affinity
 	}
 
+	if df.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = df.Spec.NodeSelector
+	}
+
 	if df.Spec.Tolerations != nil {
 		statefulset.Spec.Template.Spec.Tolerations = df.Spec.Tolerations
 	}


### PR DESCRIPTION
Hey there 👋

This PR adds nodeSelectors to dragonfly pods, addressing https://github.com/dragonflydb/dragonfly-operator/issues/80

Please let me know if I'm missing something.