### PR TITLE
feat(Openshift): Openshift CRD Flag to Ignore fsGroup

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -114,6 +114,11 @@ type DragonflySpec struct {
 	// +kubebuilder:validation:Optional
 	Snapshot *Snapshot `json:"snapshot,omitempty"`
 
+	// (Optional) Skip Assigning FileSystem Group. Required for platforms such as Openshift that require IDs to not be set, as it injects a fixed randomized ID per namespace into all pods.
+	// +optional
+	// +kubebuilder:validation:Optional
+	SkipFSGroup bool `json:"skipFSGroup,omitempty"`
+
 	// (Optional) Dragonfly Service configuration
 	// +optional
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -1130,6 +1130,11 @@ spec:
                     description: (Optional) Dragonfly Service type
                     type: string
                 type: object
+              skipFSGroup:
+                description: (Optional) Skip Assigning FileSystem Group. Required
+                  for platforms such as Openshift that require IDs to not be set,
+                  as it injects a fixed randomized ID per namespace into all pods.
+                type: boolean
               snapshot:
                 description: (Optional) Dragonfly Snapshot configuration
                 properties:

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -148,12 +148,16 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 							ImagePullPolicy: corev1.PullAlways,
 						},
 					},
-					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup: &dflyUserGroup,
-					},
 				},
 			},
 		},
+	}
+
+	// Skip Assigning FileSystem Group. Required for platforms such as Openshift that require IDs to not be set, as it injects a fixed randomized ID per namespace into all pods.
+	if !df.Spec.SkipFSGroup {
+		statefulset.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			FSGroup: &dflyUserGroup,
+		}
 	}
 
 	// set only if resources are specified


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

See Issue for details: https://github.com/dragonflydb/dragonfly-operator/issues/116

This is my current workaround: https://github.com/ArthurVardevanyan/HomeLab/blob/main/kubernetes/dragonfly-operator/base/kyverno.yaml

Deployed PR: https://github.com/ArthurVardevanyan/HomeLab/pull/63