### PR TITLE
fix(resource): add HEALTHCHECK_PORT env in the statefulset

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -114,7 +114,10 @@ func GetDragonflyResources(ctx context.Context, df *resourcesv1.Dragonfly) ([]cl
 								},
 							},
 							Args: DefaultDragonflyArgs,
-							Env:  df.Spec.Env,
+							Env: append(df.Spec.Env, corev1.EnvVar{
+								Name:  "HEALTHCHECK_PORT",
+								Value: fmt.Sprintf("%d", DragonflyAdminPort),
+							}),
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{


### PR DESCRIPTION
The healthcheck script tries to automatically finds out the dragonfly port when HEALTHCHECK_PORT not set. Dragonfly `v1.16` set the last entry (returned by `netstat` command) as the healthcheck port which may or may not be a dragonfly port. Pass the environment to the statefulset containers so that it always set the healthcheck port to dragonfly.