### PR TITLE
fix(rbac-proxy): use the correct version

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.17.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
The image that we use for rbac-proxy doesn't have 0.17.1 version. The kubebuilder proxy image has the latest `v0.16` version. As a result, the proxy container is not starting. Use the correct latest version.