### PR TITLE
fix(helm): indentation for ServiceMonitor relabelings and metricRelab…

### DIFF
--- a/charts/dragonfly-operator/templates/servicemonitor.yaml
+++ b/charts/dragonfly-operator/templates/servicemonitor.yaml
@@ -24,11 +24,11 @@ spec:
     {{- end }}
     {{- if .Values.serviceMonitor.relabelings }}
     relabelings: 
-    {{ toYaml .Values.serviceMonitor.relabelings | indent 6 }}
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
     {{- end }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings: 
-    {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 6 }}
+    {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     {{- end }}
   jobLabel: {{ template "dragonfly-operator.fullname" . }}
   namespaceSelector:


### PR DESCRIPTION
try to generate manifests:

```
helm template . --set serviceMonitor.enabled=true --debug
```

before:

```yaml
kind: ServiceMonitor
metadata:
  labels:
    helm.sh/chart: dragonfly-operator-v1.1.6
    app.kubernetes.io/name: dragonfly-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v1.1.6"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/created-by: dragonfly-operator
    app.kubernetes.io/part-of: dragonfly-operator
    app.kubernetes.io/component: controller-manager-metrics
  name: release-name-dragonfly-operator-controller-manager-metrics
spec:
  endpoints:
  - targetPort: 8443
    interval: 30s
    scrapeTimeout: 10s
    relabelings:
          - action: replace
        replacement: dev-cluster
        targetLabel: cluster
    metricRelabelings:
          - action: replace
        replacement: dev-cluster
        targetLabel: cluster
  jobLabel: release-name-dragonfly-operator
  namespaceSelector:
    matchNames:
    - default
  selector:
    matchLabels:
      app.kubernetes.io/name: dragonfly-operator
      app.kubernetes.io/instance: release-name
```

with this PR:

```yaml
kind: ServiceMonitor
metadata:
  labels:
    helm.sh/chart: dragonfly-operator-v1.1.6
    app.kubernetes.io/name: dragonfly-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v1.1.6"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/created-by: dragonfly-operator
    app.kubernetes.io/part-of: dragonfly-operator
    app.kubernetes.io/component: controller-manager-metrics
  name: release-name-dragonfly-operator-controller-manager-metrics
spec:
  endpoints:
  - targetPort: 8443
    interval: 30s
    scrapeTimeout: 10s
    relabelings:
    - action: replace
      replacement: dev-cluster
      targetLabel: cluster
    metricRelabelings:
    - action: replace
      replacement: dev-cluster
      targetLabel: cluster
  jobLabel: release-name-dragonfly-operator
  namespaceSelector:
    matchNames:
    - default
  selector:
    matchLabels:
      app.kubernetes.io/name: dragonfly-operator
      app.kubernetes.io/instance: release-name
```