### PR TITLE
feat(helm): do not set default labels for Grafana dashboards

### DIFF
--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -165,5 +165,5 @@ grafanaDashboard:
     enabled: false
     allowCrossNamespaceImport: true
     # -- Selected labels for Grafana instance
-    matchLabels:
-      dashboards: grafana
+    matchLabels: {}
+      # dashboards: grafana


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

i would to add only one label for Grafana dashboards. I set values like that:

```yaml
grafanaOperator:
      enabled: true
      allowCrossNamespaceImport: true
      matchLabels:
        grafana.com/dashboards: xxxxx
```

but in generated manifest i've got :

```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  labels:
    ....
  name: dragonfly-operator-grafana-dashboard
  namespace: database
spec:
  ...
  instanceSelector:
    matchLabels:
      dashboards: grafana
      grafana.com/dashboards: xxx
```