### PR TITLE
chore: replace gcr.io for kube-rbac-proxy image

### DIFF
--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -45,7 +45,7 @@ terminationGracePeriodSeconds: 10
 
 rbacProxy:
   image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    repository: quay.io/brancz/kube-rbac-proxy
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: v0.13.1

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -2076,7 +2076,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
This pull request updates the kube-rbac-proxy dependency to use the image hosted on quay.io/brancz/kube-rbac-proxy.

Why is this change necessary? 

- 	[Deprecation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown) of gcr.io: Images hosted under gcr.io will no longer be available after March 18, 2025.

- 	[Announcement from kubebuilder](https://book.kubebuilder.io/reference/metrics#metrics)

What does this PR do?

-  Replaces references to gcr.io/kubebuilder/kube-rbac-proxy with quay.io/brancz/kube-rbac-proxy.