### PR TITLE
fix(monitoring): remove datasource hardcode (#256)

### DIFF
--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1443,11 +1443,23 @@
 	"templating": {
 	  "list": [
 		{
-		  "hide": 2,
-		  "name": "DS_PROMETHEUS",
-		  "query": "prometheus",
-		  "skipUrlSync": true,
-		  "type": "constant"
+	          "current": {
+	        	"selected": false,
+	        	"text": "Prometheus",
+	        	"value": "prometheus"
+	          },
+	          "hide": 0,
+	          "includeAll": false,
+	          "label": "Datasource",
+	          "multi": false,
+	          "name": "DS_PROMETHEUS",
+	          "options": [],
+	          "query": "prometheus",
+	          "queryValue": "",
+	          "refresh": 1,
+	          "regex": "",
+	          "skipUrlSync": false,
+		  "type": "datasource"
 		},
 		{
 		  "current": {},


### PR DESCRIPTION
Described here: https://github.com/dragonflydb/dragonfly-operator/issues/256#issuecomment-2556772429

These changes will allow grafana to select datasource of type prometheus automatically

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->