### PR TITLE
feat(helm): add PodDisruptionBudget support, fixes ServiceMonitor, removed deprecated kube-rbac-proxy closes #280, #258

### DIFF
--- a/charts/dragonfly-operator/templates/deployment.yaml
+++ b/charts/dragonfly-operator/templates/deployment.yaml
@@ -9,6 +9,11 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "dragonfly-operator.selectorLabels" . | nindent 6 }}
@@ -35,27 +40,14 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=0
-          image: "{{ .Values.rbacProxy.image.repository }}:{{ .Values.rbacProxy.image.tag  }}"
-          imagePullPolicy: {{ .Values.rbacProxy.image.pullPolicy }}
-          name: kube-rbac-proxy
-          securityContext:
-            {{- toYaml .Values.rbacProxy.securityContext | nindent 12 }}
+        - name: manager
           ports:
-            - containerPort: 8443
+            - containerPort: {{ .Values.service.port }}
               name: https
               protocol: TCP
-          resources:
-            {{- toYaml .Values.rbacProxy.resources | nindent 12 }}
-
-        - name: manager
           args:
             - --health-probe-bind-address=:8081
-            - --metrics-bind-address=127.0.0.1:8080
+            - --metrics-bind-address=:{{ .Values.service.port }}
             - --leader-elect
           command:
             - /manager

--- a/charts/dragonfly-operator/templates/pdb.yaml
+++ b/charts/dragonfly-operator/templates/pdb.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "dragonfly-operator.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "dragonfly-operator.labels" . | nindent 4 }}
+  {{- with .Values.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: 0
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dragonfly-operator.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+{{- end }}

--- a/charts/dragonfly-operator/templates/servicemonitor.yaml
+++ b/charts/dragonfly-operator/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ include "dragonfly-operator.fullname" . }}-controller-manager-metrics
 spec:
   endpoints:
-  - targetPort: {{ .Values.service.port }}
+  - port: https
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}
@@ -23,11 +23,11 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
     {{- end }}
     {{- if .Values.serviceMonitor.relabelings }}
-    relabelings: 
+    relabelings:
     {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
     {{- end }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
-    metricRelabelings: 
+    metricRelabelings:
     {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     {{- end }}
   jobLabel: {{ template "dragonfly-operator.fullname" . }}

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -43,27 +43,6 @@ service:
 
 terminationGracePeriodSeconds: 10
 
-rbacProxy:
-  image:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
-    pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.13.1
-
-  resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 64Mi
-
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-
 manager:
   image:
     repository: docker.dragonflydb.io/dragonflydb/operator
@@ -151,6 +130,22 @@ serviceMonitor:
   #     action: replace
   #     replacement: mydbname
   #     targetLabel: dbname
+
+# The number of old ReplicaSets to retain to allow rollback.
+revisionHistoryLimit: 10
+
+# Strategy for updating the pod.
+# strategy:
+#   rollingUpdate:
+#     maxUnavailable: 1
+
+pdb:
+  # When set to true, deploys PodDisruptionBudget for the controller-manager.
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 0
+  # -- Extra annotations to be added to pdb
+  annotations: {}
 
 grafanaDashboard:
   enabled: false


### PR DESCRIPTION
* Fixes #280 
* FIxes #258 
* Removed usage of deprecated `kube-rbac-proxy` sidecar container, as  outlined here #266 
* Added support of managing `revisionHistoryLimit` and `strategy` fields on deployment resource to have a better control during updates