### PR TITLE
fix: skip terminating pods in getMasterIp

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -175,7 +175,7 @@ func (dfi *DragonflyInstance) getMasterIp(ctx context.Context) (string, error) {
 	}
 
 	for _, pod := range pods.Items {
-		if pod.Status.Phase == corev1.PodRunning && pod.Status.ContainerStatuses[0].Ready && pod.Labels[resources.Role] == resources.Master {
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.ContainerStatuses[0].Ready && pod.Labels[resources.Role] == resources.Master && pod.DeletionTimestamp == nil {
 			return pod.Status.PodIP, nil
 		}
 	}


### PR DESCRIPTION
It relates to the issue 
https://github.com/dragonflydb/dragonfly-operator/issues/289
The operator will skip masters in the termination state and no longer try to reconfigure the replication to these pods.
