### PR TITLE
fix(helm): truncate metrics service name to comply with DNS naming spec

### DIFF
--- a/charts/dragonfly-operator/templates/_helpers.tpl
+++ b/charts/dragonfly-operator/templates/_helpers.tpl
@@ -66,3 +66,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Limit metrics service name to 63 characters by truncating fullname at 28 characters to comply with DNS naming spec
+Suffix + 28 char fullname = max 63 characters
+*/}}
+{{- define "dragonfly-operator.metricsServiceName" -}}
+{{- printf "%s-controller-manager-metrics-service" (include "dragonfly-operator.fullname" . | trunc 28 | trimSuffix "-" ) -}}
+{{- end -}}

--- a/charts/dragonfly-operator/templates/_helpers.tpl
+++ b/charts/dragonfly-operator/templates/_helpers.tpl
@@ -68,9 +68,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Limit metrics service name to 63 characters by truncating fullname at 28 characters to comply with DNS naming spec
-Suffix + 28 char fullname = max 63 characters
+Limit controller service name to 63 characters by truncating fullname at 48 characters to comply with DNS naming spec
+Suffix + 48 char fullname = max 63 characters
 */}}
-{{- define "dragonfly-operator.metricsServiceName" -}}
-{{- printf "%s-controller-manager-metrics-service" (include "dragonfly-operator.fullname" . | trunc 28 | trimSuffix "-" ) -}}
+{{- define "dragonfly-operator.controllerServiceName" -}}
+{{- printf "%s-controller-svc" (include "dragonfly-operator.fullname" . | trunc 48 | trimSuffix "-" ) -}}
 {{- end -}}

--- a/charts/dragonfly-operator/templates/service.yaml
+++ b/charts/dragonfly-operator/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dragonfly-operator.fullname" . }}-controller-manager-metrics-service
+  name: {{ include "dragonfly-operator.metricsServiceName" . }}
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-rbac-proxy

--- a/charts/dragonfly-operator/templates/service.yaml
+++ b/charts/dragonfly-operator/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dragonfly-operator.metricsServiceName" . }}
+  name: {{ include "dragonfly-operator.controllerServiceName" . }}
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-rbac-proxy


### PR DESCRIPTION
This pull request includes changes to the Helm chart to ensure compliance with DNS naming specifications.

* Added a new template definition for `metricsServiceName` to truncate the fullname template to 28 characters and append a suffix, ensuring the total length does not exceed 63 characters. (`charts/dragonfly-operator/templates/_helpers.tpl`)
* Updated the service name in `service.yaml` to use the new `metricsServiceName` template. (`charts/dragonfly-operator/templates/service.yaml`)

fixes #298