### PR TITLE
Align CRD for helm chart

### DIFF
--- a/charts/dragonfly-operator/templates/crds.yaml
+++ b/charts/dragonfly-operator/templates/crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.15.0
     {{- if .Values.crds.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -26,14 +26,19 @@ spec:
           description: Dragonfly is the Schema for the dragonflies API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -48,14 +53,21 @@ spec:
                         valid secret key.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                       type: string
                     optional:
                       description: Specify whether the Secret or its key must be defined
                       type: boolean
                   required:
-                    - key
+                  - key
                   type: object
                   x-kubernetes-map-type: atomic
                 affinity:
@@ -66,22 +78,20 @@ spec:
                         pod.
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node matches
-                            the corresponding matchExpressions; the node(s) with the
-                            highest sum are the most preferred.
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                            node(s) with the highest sum are the most preferred.
                           items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects (i.e.
-                              is also a no-op).
+                            description: |-
+                              An empty preferred scheduling term matches all objects with implicit weight 0
+                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the
@@ -91,74 +101,70 @@ spec:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchFields:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
@@ -167,104 +173,102 @@ spec:
                                 format: int32
                                 type: integer
                             required:
-                              - preference
-                              - weight
+                            - preference
+                            - weight
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to an update), the system may or may not try to
-                            eventually evict the pod from its node.
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its node.
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed. The
-                                  TopologySelectorTerm type implements a subset of the
-                                  NodeSelectorTerm.
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchFields:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
-                            - nodeSelectorTerms
+                          - nodeSelectorTerms
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
@@ -273,16 +277,15 @@ spec:
                         this pod in the same node, zone, etc. as some other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm
@@ -293,288 +296,339 @@ spec:
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
-                                            - key
-                                            - operator
+                                          - key
+                                          - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
-                                            - key
-                                            - operator
+                                          - key
+                                          - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
-                                  - topologyKey
+                                - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
-                              - podAffinityTerm
-                              - weight
+                            - podAffinityTerm
+                            - weight
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to a pod label update), the system may or may
-                            not try to eventually evict the pod from its node. When
-                            there are multiple elements, the lists of nodes corresponding
-                            to each podAffinityTerm are intersected, i.e. all terms
-                            must be satisfied.
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace".
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
                                   Empty topologyKey is not allowed.
                                 type: string
                             required:
-                              - topologyKey
+                            - topologyKey
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     podAntiAffinity:
                       description: Describes pod anti-affinity scheduling rules (e.g.
@@ -582,16 +636,15 @@ spec:
                         other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates one
-                            or more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling anti-affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the anti-affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm
@@ -602,288 +655,339 @@ spec:
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
-                                            - key
-                                            - operator
+                                          - key
+                                          - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
-                                            - key
-                                            - operator
+                                          - key
+                                          - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
-                                  - topologyKey
+                                - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
-                              - podAffinityTerm
-                              - weight
+                            - podAffinityTerm
+                            - weight
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by
-                            this field are not met at scheduling time, the pod will
-                            not be scheduled onto the node. If the anti-affinity requirements
-                            specified by this field cease to be met at some point during
-                            pod execution (e.g. due to a pod label update), the system
-                            may or may not try to eventually evict the pod from its
-                            node. When there are multiple elements, the lists of nodes
-                            corresponding to each podAffinityTerm are intersected, i.e.
-                            all terms must be satisfied.
+                          description: |-
+                            If the anti-affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the anti-affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
-                                        - key
-                                        - operator
+                                      - key
+                                      - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace".
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
                                   Empty topologyKey is not allowed.
                                 type: string
                             required:
-                              - topologyKey
+                            - topologyKey
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                   type: object
                 annotations:
@@ -892,7 +996,8 @@ spec:
                   description: (Optional) Annotations to add to the Dragonfly pods.
                   type: object
                 args:
-                  description: (Optional) Dragonfly container args to pass to the container
+                  description: |-
+                    (Optional) Dragonfly container args to pass to the container
                     Refer to the Dragonfly documentation for the list of supported args
                   items:
                     type: string
@@ -901,24 +1006,31 @@ spec:
                   description: (Optional) Dragonfly Authentication mechanism
                   properties:
                     clientCaCertSecret:
-                      description: (Optional) If specified, the Dragonfly instance will
-                        check if the client certificate is signed by this CA. Server
-                        TLS must be enabled for this.
+                      description: |-
+                        (Optional) If specified, the Dragonfly instance will check if the
+                        client certificate is signed by this CA. Server TLS must be enabled for this.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must be
                             a valid secret key.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                         optional:
                           description: Specify whether the Secret or its key must be
                             defined
                           type: boolean
                       required:
-                        - key
+                      - key
                       type: object
                       x-kubernetes-map-type: atomic
                     passwordFromSecret:
@@ -930,15 +1042,22 @@ spec:
                             a valid secret key.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                         optional:
                           description: Specify whether the Secret or its key must be
                             defined
                           type: boolean
                       required:
-                        - key
+                      - key
                       type: object
                       x-kubernetes-map-type: atomic
                   type: object
@@ -1143,15 +1262,16 @@ spec:
                         description: Name of the environment variable. Must be a C_IDENTIFIER.
                         type: string
                       value:
-                        description: 'Variable references $(VAR_NAME) are expanded using
-                        the previously defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        Double $$ are reduced to a single $, which allows for escaping
-                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
-                        string literal "$(VAR_NAME)". Escaped references will never
-                        be expanded, regardless of whether the variable exists or
-                        not. Defaults to "".'
+                        description: |-
+                          Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the container and
+                          any service environment variables. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of whether the variable
+                          exists or not.
+                          Defaults to "".
                         type: string
                       valueFrom:
                         description: Source for the environment variable's value. Cannot
@@ -1164,22 +1284,28 @@ spec:
                                 description: The key to select.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its key
                                   must be defined
                                 type: boolean
                             required:
-                              - key
+                            - key
                             type: object
                             x-kubernetes-map-type: atomic
                           fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                             properties:
                               apiVersion:
                                 description: Version of the schema the FieldPath is
@@ -1190,23 +1316,22 @@ spec:
                                   API version.
                                 type: string
                             required:
-                              - fieldPath
+                            - fieldPath
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                             properties:
                               containerName:
                                 description: 'Container name: required for volumes,
-                                optional for env vars'
+                                  optional for env vars'
                                 type: string
                               divisor:
                                 anyOf:
-                                  - type: integer
-                                  - type: string
+                                - type: integer
+                                - type: string
                                 description: Specifies the output format of the exposed
                                   resources, defaults to "1"
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -1215,7 +1340,7 @@ spec:
                                 description: 'Required: resource to select'
                                 type: string
                             required:
-                              - resource
+                            - resource
                             type: object
                             x-kubernetes-map-type: atomic
                           secretKeyRef:
@@ -1226,25 +1351,1486 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key must
                                   be defined
                                 type: boolean
                             required:
-                              - key
+                            - key
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
                     required:
-                      - name
+                    - name
                     type: object
                   type: array
                 image:
                   description: Image is the Dragonfly image to use
                   type: string
+                imagePullPolicy:
+                  default: Always
+                  description: (Optional) imagePullPolicy to set to Dragonfly, default
+                    is Always
+                  type: string
+                imagePullSecrets:
+                  description: (Optional) imagePullSecrets to set to Dragonfly
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                initContainers:
+                  description: (Optional) Dragonfly pod init containers
+                  items:
+                    description: A single application container that you want to run
+                      within a pod.
+                    properties:
+                      args:
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      command:
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be
+                                a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      image:
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                        type: string
+                      lifecycle:
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          Cannot be updated.
+                        properties:
+                          postStart:
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds to
+                                      sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds to
+                                      sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: |-
+                              How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
+                        items:
+                          description: ContainerPort represents a network port in a
+                            single container.
+                          properties:
+                            containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port to.
+                              type: string
+                            hostPort:
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: |-
+                              How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            format: int32
+                            type: integer
+                        type: object
+                      resizePolicy:
+                        description: Resources resize policy for the container.
+                        items:
+                          description: ContainerResizePolicy represents resource resize
+                            policy for the container.
+                          properties:
+                            resourceName:
+                              description: |-
+                                Name of the resource to which this resource resize policy applies.
+                                Supported values: cpu, memory.
+                              type: string
+                            restartPolicy:
+                              description: |-
+                                Restart policy to apply when specified resource is resized.
+                                If not specified, it defaults to NotRequired.
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      resources:
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      restartPolicy:
+                        description: |-
+                          RestartPolicy defines the restart behavior of individual containers in a pod.
+                          This field may only be set for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod's restart policy and the container type.
+                          Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                          this init container will be continually restarted on
+                          exit until all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy "Always"
+                          will be shut down. This lifecycle differs from normal init containers and
+                          is often referred to as a "sidecar" container. Although this init
+                          container still starts in the init container sequence, it does not wait
+                          for the container to complete before proceeding to the next init
+                          container. Instead, the next init container starts immediately after this
+                          init container is started, or after any startupProbe has successfully
+                          completed.
+                        type: string
+                      securityContext:
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                              overrides the pod's appArmorProfile.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          privileged:
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      startupProbe:
+                        description: |-
+                          StartupProbe indicates that the Pod has successfully initialized.
+                          If specified, no other probes are executed until this completes successfully.
+                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                          when it might take a long time to load data or warm a cache, than during steady-state operation.
+                          This cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: |-
+                              How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            format: int32
+                            type: integer
+                        type: object
+                      stdin:
+                        description: |-
+                          Whether this container should allocate a buffer for stdin in the container runtime. If this
+                          is not set, reads from stdin in the container will always result in EOF.
+                          Default is false.
+                        type: boolean
+                      stdinOnce:
+                        description: |-
+                          Whether the container runtime should close the stdin channel after it has been opened by
+                          a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                          sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                          first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                          at which time stdin is closed and remains closed until the container is restarted. If this
+                          flag is false, a container processes that reads from stdin will never receive an EOF.
+                          Default is false
+                        type: boolean
+                      terminationMessagePath:
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
+                        type: string
+                      terminationMessagePolicy:
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
+                        type: string
+                      tty:
+                        description: |-
+                          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                          Default is false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to be
+                          used by the container.
+                        items:
+                          description: volumeDevice describes a mapping of a raw block
+                            device within a container.
+                          properties:
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
+                              type: string
+                            name:
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
+                              type: string
+                          required:
+                          - devicePath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - devicePath
+                        x-kubernetes-list-type: map
+                      volumeMounts:
+                        description: |-
+                          Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                                When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                (which defaults to None).
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
+                              type: boolean
+                            recursiveReadOnly:
+                              description: |-
+                                RecursiveReadOnly specifies whether read-only mounts should be handled
+                                recursively.
+
+
+                                If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                recursively read-only.  If this field is set to IfPossible, the mount is made
+                                recursively read-only, if it is supported by the container runtime.  If this
+                                field is set to Enabled, the mount is made recursively read-only if it is
+                                supported by the container runtime, otherwise the pod will not be started and
+                                an error will be generated to indicate the reason.
+
+
+                                If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                None (or be unspecified, which defaults to None).
+
+
+                                If this field is not specified, it is treated as an equivalent of Disabled.
+                              type: string
+                            subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - mountPath
+                        x-kubernetes-list-type: map
+                      workingDir:
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
                 labels:
                   additionalProperties:
                     type: string
@@ -1457,7 +3043,7 @@ spec:
                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: string
                       type: object
-                  type: object 
+                  type: object
                 priorityClassName:
                   description: (Optional) Dragonfly pod priority class name
                   type: string
@@ -1467,51 +3053,60 @@ spec:
                   format: int32
                   type: integer
                 resources:
-                  description: (Optional) Dragonfly container resource limits. Any container
-                    limits can be specified.
+                  description: |-
+                    (Optional) Dragonfly container resource limits. Any container limits
+                    can be specified.
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable. It can only be set
-                      for containers."
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+
+
+                        This field is immutable. It can only be set for containers.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims
-                              of the Pod where this field is used. It makes that resource
-                              available inside a container.
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
                             type: string
                         required:
-                          - name
+                        - name
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:
-                        - name
+                      - name
                       x-kubernetes-list-type: map
                     limits:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       type: object
                     requests:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       type: object
                   type: object
                 serviceAccountName:
@@ -1525,6 +3120,18 @@ spec:
                         type: string
                       description: (Optional) Dragonfly Service Annotations
                       type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: (Optional) Dragonfly Service Labels
+                      type: object
+                    name:
+                      description: (Optional) Dragonfly Service name
+                      type: string
+                    nodePort:
+                      description: (Optional) Dragonfly Service nodePort
+                      format: int32
+                      type: integer
                     type:
                       description: (Optional) Dragonfly Service type
                       type: string
@@ -1541,37 +3148,38 @@ spec:
                       description: (Optional) Dragonfly snapshot schedule
                       type: string
                     dir:
-                      description: (Optional) The path to the snapshot directory This
-                        can also be an S3 URI with the prefix `s3://` when using S3
-                        as the snapshot backend
+                      description: |-
+                        (Optional) The path to the snapshot directory
+                        This can also be an S3 URI with the prefix `s3://` when
+                        using S3 as the snapshot backend
                       type: string
                     persistentVolumeClaimSpec:
                       description: (Optional) Dragonfly PVC spec
                       properties:
                         accessModes:
-                          description: 'accessModes contains the desired access modes
-                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          description: |-
+                            accessModes contains the desired access modes the volume should have.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         dataSource:
-                          description: 'dataSource field can be used to specify either:
-                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                          * An existing PVC (PersistentVolumeClaim) If the provisioner
-                          or an external controller can support the specified data
-                          source, it will create a new volume based on the contents
-                          of the specified data source. When the AnyVolumeDataSource
-                          feature gate is enabled, dataSource contents will be copied
-                          to dataSourceRef, and dataSourceRef contents will be copied
-                          to dataSource when dataSourceRef.namespace is not specified.
-                          If the namespace is specified, then dataSourceRef will not
-                          be copied to dataSource.'
+                          description: |-
+                            dataSource field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            * An existing PVC (PersistentVolumeClaim)
+                            If the provisioner or an external controller can support the specified data source,
+                            it will create a new volume based on the contents of the specified data source.
+                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                           properties:
                             apiGroup:
-                              description: APIGroup is the group for the resource being
-                                referenced. If APIGroup is not specified, the specified
-                                Kind must be in the core API group. For any other third-party
-                                types, APIGroup is required.
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
                               type: string
                             kind:
                               description: Kind is the type of resource being referenced
@@ -1580,43 +3188,41 @@ spec:
                               description: Name is the name of resource being referenced
                               type: string
                           required:
-                            - kind
-                            - name
+                          - kind
+                          - name
                           type: object
                           x-kubernetes-map-type: atomic
                         dataSourceRef:
-                          description: 'dataSourceRef specifies the object from which
-                          to populate the volume with data, if a non-empty volume
-                          is desired. This may be any object from a non-empty API
-                          group (non core object) or a PersistentVolumeClaim object.
-                          When this field is specified, volume binding will only succeed
-                          if the type of the specified object matches some installed
-                          volume populator or dynamic provisioner. This field will
-                          replace the functionality of the dataSource field and as
-                          such if both fields are non-empty, they must have the same
-                          value. For backwards compatibility, when namespace isn''t
-                          specified in dataSourceRef, both fields (dataSource and
-                          dataSourceRef) will be set to the same value automatically
-                          if one of them is empty and the other is non-empty. When
-                          namespace is specified in dataSourceRef, dataSource isn''t
-                          set to the same value and must be empty. There are three
-                          important differences between dataSource and dataSourceRef:
-                          * While dataSource only allows two specific types of objects,
-                          dataSourceRef allows any non-core object, as well as PersistentVolumeClaim
-                          objects. * While dataSource ignores disallowed values (dropping
-                          them), dataSourceRef preserves all values, and generates
-                          an error if a disallowed value is specified. * While dataSource
-                          only allows local objects, dataSourceRef allows objects
-                          in any namespaces. (Beta) Using this field requires the
-                          AnyVolumeDataSource feature gate to be enabled. (Alpha)
-                          Using the namespace field of dataSourceRef requires the
-                          CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                          description: |-
+                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                            volume is desired. This may be any object from a non-empty API group (non
+                            core object) or a PersistentVolumeClaim object.
+                            When this field is specified, volume binding will only succeed if the type of
+                            the specified object matches some installed volume populator or dynamic
+                            provisioner.
+                            This field will replace the functionality of the dataSource field and as such
+                            if both fields are non-empty, they must have the same value. For backwards
+                            compatibility, when namespace isn't specified in dataSourceRef,
+                            both fields (dataSource and dataSourceRef) will be set to the same
+                            value automatically if one of them is empty and the other is non-empty.
+                            When namespace is specified in dataSourceRef,
+                            dataSource isn't set to the same value and must be empty.
+                            There are three important differences between dataSource and dataSourceRef:
+                            * While dataSource only allows two specific types of objects, dataSourceRef
+                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                              preserves all values, and generates an error if a disallowed value is
+                              specified.
+                            * While dataSource only allows local objects, dataSourceRef allows objects
+                              in any namespaces.
+                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                           properties:
                             apiGroup:
-                              description: APIGroup is the group for the resource being
-                                referenced. If APIGroup is not specified, the specified
-                                Kind must be in the core API group. For any other third-party
-                                types, APIGroup is required.
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
                               type: string
                             kind:
                               description: Kind is the type of resource being referenced
@@ -1625,71 +3231,46 @@ spec:
                               description: Name is the name of resource being referenced
                               type: string
                             namespace:
-                              description: Namespace is the namespace of resource being
-                                referenced Note that when a namespace is specified,
-                                a gateway.networking.k8s.io/ReferenceGrant object is
-                                required in the referent namespace to allow that namespace's
-                                owner to accept the reference. See the ReferenceGrant
-                                documentation for details. (Alpha) This field requires
-                                the CrossNamespaceVolumeDataSource feature gate to be
-                                enabled.
+                              description: |-
+                                Namespace is the namespace of resource being referenced
+                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                               type: string
                           required:
-                            - kind
-                            - name
+                          - kind
+                          - name
                           type: object
                         resources:
-                          description: 'resources represents the minimum resources the
-                          volume should have. If RecoverVolumeExpansionFailure feature
-                          is enabled users are allowed to specify resource requirements
-                          that are lower than previous value but must still be higher
-                          than capacity recorded in the status field of the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                          description: |-
+                            resources represents the minimum resources the volume should have.
+                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                            that are lower than previous value but must still be higher than capacity recorded in the
+                            status field of the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                           properties:
-                            claims:
-                              description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
-                              items:
-                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                properties:
-                                  name:
-                                    description: Name must match the name of one entry
-                                      in pod.spec.resourceClaims of the Pod where this
-                                      field is used. It makes that resource available
-                                      inside a container.
-                                    type: string
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - name
-                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
-                                  - type: integer
-                                  - type: string
+                                - type: integer
+                                - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               type: object
                             requests:
                               additionalProperties:
                                 anyOf:
-                                  - type: integer
-                                  - type: string
+                                - type: integer
+                                - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               type: object
                           type: object
                         selector:
@@ -1700,8 +3281,8 @@ spec:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -1709,44 +3290,60 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In, NotIn,
-                                      Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists or
-                                      DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
-                                  - key
-                                  - operator
+                                - key
+                                - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field is
-                                "key", the operator is "In", and the values array contains
-                                only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         storageClassName:
-                          description: 'storageClassName is the name of the StorageClass
-                          required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          description: |-
+                            storageClassName is the name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                          type: string
+                        volumeAttributesClassName:
+                          description: |-
+                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                            If specified, the CSI driver will create or update the volume with the attributes defined
+                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                            will be set by the persistentvolume controller if it exists.
+                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                            exists.
+                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                           type: string
                         volumeMode:
-                          description: volumeMode defines what type of volume is required
-                            by the claim. Value of Filesystem is implied when not included
-                            in claim spec.
+                          description: |-
+                            volumeMode defines what type of volume is required by the claim.
+                            Value of Filesystem is implied when not included in claim spec.
                           type: string
                         volumeName:
                           description: volumeName is the binding reference to the PersistentVolume
@@ -1755,9 +3352,10 @@ spec:
                       type: object
                   type: object
                 tlsSecretRef:
-                  description: (Optional) Dragonfly TLS secret to used for TLS Connections
-                    to Dragonfly. Dragonfly instance  must have access to this secret
-                    and be in the same namespace
+                  description: |-
+                    (Optional) Dragonfly TLS secret to used for TLS
+                    Connections to Dragonfly. Dragonfly instance  must
+                    have access to this secret and be in the same namespace
                   properties:
                     name:
                       description: name is unique within a namespace to reference a
@@ -1772,40 +3370,39 @@ spec:
                 tolerations:
                   description: (Optional) Dragonfly pod tolerations
                   items:
-                    description: The pod this Toleration is attached to tolerates any
-                      taint that matches the triple <key,value,effect> using the matching
-                      operator <operator>.
+                    description: |-
+                      The pod this Toleration is attached to tolerates any taint that matches
+                      the triple <key,value,effect> using the matching operator <operator>.
                     properties:
                       effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        description: |-
+                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
                       key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match all
-                          values and all keys.
+                        description: |-
+                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                         type: string
                       operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod
-                          can tolerate all taints of a particular category.
+                        description: |-
+                          Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod can
+                          tolerate all taints of a particular category.
                         type: string
                       tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default, it
-                          is not set, which means tolerate the taint forever (do not
-                          evict). Zero and negative values will be treated as 0 (evict
-                          immediately) by the system.
+                        description: |-
+                          TolerationSeconds represents the period of time the toleration (which must be
+                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                          negative values will be treated as 0 (evict immediately) by the system.
                         format: int64
                         type: integer
                       value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
+                        description: |-
+                          Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise just a regular string.
                         type: string
                     type: object
                   type: array
@@ -1816,165 +3413,177 @@ spec:
                       pods among the given topology.
                     properties:
                       labelSelector:
-                        description: LabelSelector is used to find matching pods. Pods
-                          that match this label selector are counted to determine the
-                          number of pods in their corresponding topology domain.
+                        description: |-
+                          LabelSelector is used to find matching pods.
+                          Pods that match this label selector are counted to determine the number of pods
+                          in their corresponding topology domain.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that relates
-                                the key and values.
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
                                   description: key is the label key that the selector
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty. This
-                                    array is replaced during a strategic merge patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               required:
-                                - key
-                                - operator
+                              - key
+                              - operator
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       matchLabelKeys:
-                        description: MatchLabelKeys is a set of pod label keys to select
-                          the pods over which spreading will be calculated. The keys
-                          are used to lookup values from the incoming pod labels, those
-                          key-value labels are ANDed with labelSelector to select the
-                          group of existing pods over which spreading will be calculated
-                          for the incoming pod. Keys that don't exist in the incoming
-                          pod labels will be ignored. A null or empty list means only
-                          match against labelSelector.
+                        description: |-
+                          MatchLabelKeys is a set of pod label keys to select the pods over which
+                          spreading will be calculated. The keys are used to lookup values from the
+                          incoming pod labels, those key-value labels are ANDed with labelSelector
+                          to select the group of existing pods over which spreading will be calculated
+                          for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                          MatchLabelKeys cannot be set when LabelSelector isn't set.
+                          Keys that don't exist in the incoming pod labels will
+                          be ignored. A null or empty list means only match against labelSelector.
+
+
+                          This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       maxSkew:
-                        description: 'MaxSkew describes the degree to which pods may
-                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                        it is the maximum permitted difference between the number
-                        of matching pods in the target topology and the global minimum.
-                        The global minimum is the minimum number of matching pods
-                        in an eligible domain or zero if the number of eligible domains
-                        is less than MinDomains. For example, in a 3-zone cluster,
-                        MaxSkew is set to 1, and pods with the same labelSelector
-                        spread as 2/2/1: In this case, the global minimum is 1. |
-                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                        is 1, incoming pod can only be scheduled to zone3 to become
-                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
-                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
-                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                        it is used to give higher precedence to topologies that satisfy
-                        it. It''s a required field. Default value is 1 and 0 is not
-                        allowed.'
+                        description: |-
+                          MaxSkew describes the degree to which pods may be unevenly distributed.
+                          When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                          between the number of matching pods in the target topology and the global minimum.
+                          The global minimum is the minimum number of matching pods in an eligible domain
+                          or zero if the number of eligible domains is less than MinDomains.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 2/2/1:
+                          In this case, the global minimum is 1.
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |   P   |
+                          - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                          scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                          violate MaxSkew(1).
+                          - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                          When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                          to topologies that satisfy it.
+                          It's a required field. Default value is 1 and 0 is not allowed.
                         format: int32
                         type: integer
                       minDomains:
-                        description: "MinDomains indicates a minimum number of eligible
-                        domains. When the number of eligible domains with matching
-                        topology keys is less than minDomains, Pod Topology Spread
-                        treats \"global minimum\" as 0, and then the calculation of
-                        Skew is performed. And when the number of eligible domains
-                        with matching topology keys equals or greater than minDomains,
-                        this value has no effect on scheduling. As a result, when
-                        the number of eligible domains is less than minDomains, scheduler
-                        won't schedule more than maxSkew Pods to those domains. If
-                        value is nil, the constraint behaves as if MinDomains is equal
-                        to 1. Valid values are integers greater than 0. When value
-                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
-                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
-                        is set to 5 and pods with the same labelSelector spread as
-                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                        The number of domains is less than 5(MinDomains), so \"global
-                        minimum\" is treated as 0. In this situation, new pod with
-                        the same labelSelector cannot be scheduled, because computed
-                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is a beta field
-                        and requires the MinDomainsInPodTopologySpread feature gate
-                        to be enabled (enabled by default)."
+                        description: |-
+                          MinDomains indicates a minimum number of eligible domains.
+                          When the number of eligible domains with matching topology keys is less than minDomains,
+                          Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                          And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                          this value has no effect on scheduling.
+                          As a result, when the number of eligible domains is less than minDomains,
+                          scheduler won't schedule more than maxSkew Pods to those domains.
+                          If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                          Valid values are integers greater than 0.
+                          When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                          labelSelector spread as 2/2/2:
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |  P P  |
+                          The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                          In this situation, new pod with the same labelSelector cannot be scheduled,
+                          because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                          it will violate MaxSkew.
                         format: int32
                         type: integer
                       nodeAffinityPolicy:
-                        description: "NodeAffinityPolicy indicates how we will treat
-                        Pod's nodeAffinity/nodeSelector when calculating pod topology
-                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
-                        are ignored. All nodes are included in the calculations. \n
-                        If this value is nil, the behavior is equivalent to the Honor
-                        policy. This is a beta-level feature default enabled by the
-                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: |-
+                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                          when calculating pod topology spread skew. Options are:
+                          - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                          - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                          If this value is nil, the behavior is equivalent to the Honor policy.
+                          This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                         type: string
                       nodeTaintsPolicy:
-                        description: "NodeTaintsPolicy indicates how we will treat node
-                        taints when calculating pod topology spread skew. Options
-                        are: - Honor: nodes without taints, along with tainted nodes
-                        for which the incoming pod has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
-                        \n If this value is nil, the behavior is equivalent to the
-                        Ignore policy. This is a beta-level feature default enabled
-                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: |-
+                          NodeTaintsPolicy indicates how we will treat node taints when calculating
+                          pod topology spread skew. Options are:
+                          - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                          has a toleration, are included.
+                          - Ignore: node taints are ignored. All nodes are included.
+
+
+                          If this value is nil, the behavior is equivalent to the Ignore policy.
+                          This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                         type: string
                       topologyKey:
-                        description: TopologyKey is the key of node labels. Nodes that
-                          have a label with this key and identical values are considered
-                          to be in the same topology. We consider each <key, value>
-                          as a "bucket", and try to put balanced number of pods into
-                          each bucket. We define a domain as a particular instance of
-                          a topology. Also, we define an eligible domain as a domain
-                          whose nodes meet the requirements of nodeAffinityPolicy and
-                          nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                          each Node is a domain of that topology. And, if TopologyKey
-                          is "topology.kubernetes.io/zone", each zone is a domain of
-                          that topology. It's a required field.
+                        description: |-
+                          TopologyKey is the key of node labels. Nodes that have a label with this key
+                          and identical values are considered to be in the same topology.
+                          We consider each <key, value> as a "bucket", and try to put balanced number
+                          of pods into each bucket.
+                          We define a domain as a particular instance of a topology.
+                          Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                          nodeAffinityPolicy and nodeTaintsPolicy.
+                          e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                          And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                          It's a required field.
                         type: string
                       whenUnsatisfiable:
-                        description: 'WhenUnsatisfiable indicates how to deal with a
-                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                        tells the scheduler to schedule the pod in any location, but
-                        giving higher precedence to topologies that would help reduce
-                        the skew. A constraint is considered "Unsatisfiable" for an
-                        incoming pod if and only if every possible node assignment
-                        for that pod would violate "MaxSkew" on some topology. For
-                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
-                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
-                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
-                        set to DoNotSchedule, incoming pod can only be scheduled to
-                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
-                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
-                        can still be imbalanced, but scheduler won''t make it *more*
-                        imbalanced. It''s a required field.'
+                        description: |-
+                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                          the spread constraint.
+                          - DoNotSchedule (default) tells the scheduler not to schedule it.
+                          - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                            but giving higher precedence to topologies that would help reduce the
+                            skew.
+                          A constraint is considered "Unsatisfiable" for an incoming pod
+                          if and only if every possible node assignment for that pod would violate
+                          "MaxSkew" on some topology.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 3/1/1:
+                          | zone1 | zone2 | zone3 |
+                          | P P P |   P   |   P   |
+                          If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                          to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                          MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                          won't make it *more* imbalanced.
+                          It's a required field.
                         type: string
                     required:
-                      - maxSkew
-                      - topologyKey
-                      - whenUnsatisfiable
+                    - maxSkew
+                    - topologyKey
+                    - whenUnsatisfiable
                     type: object
                   type: array
               type: object
@@ -1986,11 +3595,12 @@ spec:
                     being updated
                   type: boolean
                 phase:
-                  description: 'Status of the Dragonfly Instance It can be one of the
-                  following: - "ready": The Dragonfly instance is ready to serve requests
-                  - "configuring-replication": The controller is updating the master
-                  of the Dragonfly instance - "resources-created": The Dragonfly instance
-                  resources were created but not yet configured'
+                  description: |-
+                    Status of the Dragonfly Instance
+                    It can be one of the following:
+                    - "ready": The Dragonfly instance is ready to serve requests
+                    - "configuring-replication": The controller is updating the master of the Dragonfly instance
+                    - "resources-created": The Dragonfly instance resources were created but not yet configured
                   type: string
               type: object
           type: object


### PR DESCRIPTION
Fixing (not only) the https://github.com/dragonflydb/dragonfly-operator/issues/197#issuecomment-2720693870 also for the helm chart.

I just copied `config/crd/bases/dragonflydb.io_dragonflies.yaml` into the `charts/dragonfly-operator/templates/crds.yaml` so all the new values are there. I mainly need the `imagePullSecrets` value, but let's also add the rest. I tested it on my cluster and it works as expected.