### PR TITLE
fix: Operator chart blocking access to metrics endpoint

### DIFF
--- a/charts/dragonfly-operator/templates/deployment.yaml
+++ b/charts/dragonfly-operator/templates/deployment.yaml
@@ -54,8 +54,6 @@ spec:
 
         - name: manager
           args:
-            - --health-probe-bind-address=:8081
-            - --metrics-bind-address=127.0.0.1:8080
             - --leader-elect
           command:
             - /manager


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

The metrics endpoint only listens on localhost, making it impossible for metrics scrapers (prometheus, victoriametrics) to reach. This PR removes the bind-address arguments (the health probe argument is redundant as it's set to the program's default value), which will allow scrapers to reach the pods.

https://github.com/dragonflydb/dragonfly-operator/pull/281 is probably preferable to this PR, but there have been no reviews from maintainers. I'm hoping that filing a different approach to the issue will get somebody's attention.

Fixes https://github.com/dragonflydb/dragonfly-operator/issues/301