### PR TITLE
fix(pod-lifecycle): improve replication management

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -223,7 +223,7 @@ func (dfi *DragonflyInstance) checkReplicaRole(ctx context.Context, pod *corev1.
 		}
 	}
 
-	if redisRole != resources.Replica {
+	if redisRole == resources.Master {
 		return false, nil
 	}
 


### PR DESCRIPTION
Replication role for replicas is actually "slave" and not "replica". 