### PR TITLE
feat: allow to pass extra args to containers

### DIFF
--- a/charts/dragonfly-operator/templates/deployment.yaml
+++ b/charts/dragonfly-operator/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
+            {{- with .Values.rbacProxy.extraArgs}}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.rbacProxy.image.repository }}:{{ .Values.rbacProxy.image.tag  }}"
           imagePullPolicy: {{ .Values.rbacProxy.image.pullPolicy }}
           name: kube-rbac-proxy
@@ -60,6 +63,9 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080
             - --leader-elect
+            {{- with .Values.manager.extraArgs}}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           command:
             - /manager
           securityContext:

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -51,6 +51,8 @@ rbacProxy:
     # Overrides the image tag whose default is the chart appVersion.
     tag: v0.13.1
 
+  extraArgs: {}
+
   resources:
     limits:
       cpu: 500m
@@ -72,6 +74,7 @@ manager:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+  extraArgs: {}
 
   resources: {}
 #    limits:


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
**Title:**  Allow to pass extra flags to containers

**Description:** This PR allows to pass extra args to both the rbac proxy and the manager. I mostly need this change in order to configure the logging level/encoding.