### PR TITLE
Include namespace in service.yaml template

### DIFF
--- a/charts/dragonfly-operator/templates/service.yaml
+++ b/charts/dragonfly-operator/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-rbac-proxy
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Every other template has `namespace: {{ .Release.Namespace | quote }}`. Only service.yaml is missing it creating problems when deploying declaratively via helmfile. This change brings it to the same standard.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->