### PR TITLE
fix(helm): Add PDB permissions to helm chart clusterroles

### DIFF
--- a/charts/dragonfly-operator/templates/clusterroles.yaml
+++ b/charts/dragonfly-operator/templates/clusterroles.yaml
@@ -51,6 +51,18 @@ rules:
       - update
       - watch
   - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - dragonflydb.io
     resources:
       - dragonflies


### PR DESCRIPTION
This PR adds a missing permission to operator's clusterrole to manage PDBs for multi-replica deployment. Currently on v1.2.0 operator produces errors due to these missing.