### PR TITLE
feat(operator): Add support for PVC retention policy

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -169,6 +170,11 @@ type DragonflySpec struct {
 	// +optional
 	// +kubebuilder:validation:Optional
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
+
+	// (Optional) StatefulSet PVC Retention Policy
+	// +optional
+	// +kubebuilder:validation:Optional
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
 }
 
 type ServiceSpec struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -234,6 +235,11 @@ func (in *DragonflySpec) DeepCopyInto(out *DragonflySpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.PersistentVolumeClaimRetentionPolicy != nil {
+		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
+		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -6043,6 +6043,25 @@ spec:
                   type: string
                 description: (Optional) Dragonfly pod node selector
                 type: object
+              persistentVolumeClaimRetentionPolicy:
+                description: (Optional) StatefulSet PVC Retention Policy
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
               podSecurityContext:
                 description: (Optional) Dragonfly pod security context
                 properties:

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -369,6 +369,10 @@ func GenerateDragonflyResources(df *resourcesv1.Dragonfly) ([]client.Object, err
 		}
 	}
 
+	if df.Spec.PersistentVolumeClaimRetentionPolicy != nil {
+		statefulset.Spec.PersistentVolumeClaimRetentionPolicy = df.Spec.PersistentVolumeClaimRetentionPolicy
+	}
+
 	statefulset.Spec.Template.Spec.Containers = mergeNamedSlices(
 		statefulset.Spec.Template.Spec.Containers, df.Spec.AdditionalContainers,
 		func(c corev1.Container) string { return c.Name })

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6042,6 +6042,25 @@ spec:
                   type: string
                 description: (Optional) Dragonfly pod node selector
                 type: object
+              persistentVolumeClaimRetentionPolicy:
+                description: (Optional) StatefulSet PVC Retention Policy
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
               podSecurityContext:
                 description: (Optional) Dragonfly pod security context
                 properties:

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -6055,6 +6055,25 @@ spec:
                   type: string
                 description: (Optional) Dragonfly pod node selector
                 type: object
+              persistentVolumeClaimRetentionPolicy:
+                description: (Optional) StatefulSet PVC Retention Policy
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
               podSecurityContext:
                 description: (Optional) Dragonfly pod security context
                 properties:


### PR DESCRIPTION
Implements #340 

 * Extended the Dragonfly resource with a `persistentVolumeClaimRetentionPolicy` field using the struct from appsv1
 * Added the conditional in the primary `GenerateDragonflyResource` function to set it in the StatefulSet if present

I've added tests but I've not used this testing harness before so sorry if I've not done it right/put it in the wrong place.

I've tested locally and things work as I'd expect:
 * If the policy isn't set it defaults to Retain
 * If set, the STS reflects it

This would only work on Kubernetes clusters running 1.27+ where StatefulSetAutoDeletePVC went into BETA (GA as of 1.32). That feels like a good enough number of versions/time that we don't need to lock this behind a feature gate/flag, but let me know if you'd want me to add that so this doesn't break on older clusters.