### PR TITLE
fix(helm): update CRDs in chart

### DIFF
--- a/charts/dragonfly-operator/templates/crds.yaml
+++ b/charts/dragonfly-operator/templates/crds.yaml
@@ -1,8 +1,15 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: dragonflies.dragonflydb.io
 spec:
   group: dragonflydb.io
@@ -7055,3 +7062,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}


### PR DESCRIPTION
### Why ?
After installing the operator with the latest version (`1.2.1`), we get an old CRD version, which lacks recent features (ex: the tiering block).
And I'm guessing that this old version is not intended, and just a forgotten step during the release process. Thus this PR to update it.

### Notes
This PR seems huge in term of lines added/modified/removed, but I did no real change.
I only performed 2 steps:
```
cd ~/git/dragonfly-operator/

cp manifests/crd.yaml charts/dragonfly-operator/templates/crds.yaml
git add charts/dragonfly-operator/templates/crds.yaml
git ci s -m "Copy simply CRD from manifests/ dir"

vim charts/dragonfly-operator/templates/crds.yaml
git add charts/dragonfly-operator/templates/crds.yaml
git ci -s -m "Reinclude the few helm wrapper lines (top & bottom of file)"
```

NB: also, don't hesitate to look at diff without whitespace (there has been changes in that area)