### PR TITLE
feat[resources]: push custom labels on STS itself

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -62,7 +62,7 @@ type DragonflySpec struct {
 	// +kubebuilder:validation:Optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// (Optional) Labels to add to the Dragonfly pods.
+	// (Optional) Labels to add to the Dragonfly pods and StatefulSet.
 	// +optional
 	// +kubebuilder:validation:Optional
 	Labels map[string]string `json:"labels,omitempty"`

--- a/charts/dragonfly-operator/templates/crds.yaml
+++ b/charts/dragonfly-operator/templates/crds.yaml
@@ -2834,7 +2834,7 @@ spec:
                 labels:
                   additionalProperties:
                     type: string
-                  description: (Optional) Labels to add to the Dragonfly pods.
+                  description: (Optional) Labels to add to the Dragonfly pods and StatefulSet.
                   type: object
                 memcachedPort:
                   description: (Optional) Dragonfly memcached port

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -6032,7 +6032,7 @@ spec:
               labels:
                 additionalProperties:
                   type: string
-                description: (Optional) Labels to add to the Dragonfly pods.
+                description: (Optional) Labels to add to the Dragonfly pods and StatefulSet.
                 type: object
               memcachedPort:
                 description: (Optional) Dragonfly memcached port

--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -60,9 +60,11 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 		"--vmodule=replica=1,server_family=1",
 	}
 
+	customLabelName := "a.custom/label"
+	customLabelValue := "my-value"
+
 	labels := map[string]string{
-		"a.custom/label":  "a-custom-value",
-		"a.custom/label2": "a-custom-value2",
+		customLabelName: customLabelValue,
 	}
 
 	df := resourcesv1.Dragonfly{
@@ -153,7 +155,7 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			Expect(err).To(BeNil())
 
 			// check labels of statefulset
-			Expect(ss.Labels).To(Equal(df.Spec.Labels))
+			Expect(ss.Labels[customLabelName]).To(Equal(df.Spec.Labels[customLabelName]))
 			// check resource requirements of statefulset
 			Expect(ss.Spec.Template.Spec.Containers[0].Resources).To(Equal(*df.Spec.Resources))
 			// check args of statefulset

--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -60,6 +60,11 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 		"--vmodule=replica=1,server_family=1",
 	}
 
+	labels := map[string]string{
+		"a.custom/label":  "a-custom-value",
+		"a.custom/label2": "a-custom-value2",
+	}
+
 	df := resourcesv1.Dragonfly{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -69,6 +74,7 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			Replicas:  3,
 			Resources: &resourcesReq,
 			Args:      args,
+			Labels:    labels,
 			Env: []corev1.EnvVar{
 				{
 					Name:  "ENV-1",
@@ -146,6 +152,8 @@ var _ = Describe("Dragonfly Lifecycle tests", Ordered, FlakeAttempts(3), func() 
 			}, &svc)
 			Expect(err).To(BeNil())
 
+			// check labels of statefulset
+			Expect(ss.Labels).To(Equal(df.Spec.Labels))
 			// check resource requirements of statefulset
 			Expect(ss.Spec.Template.Spec.Containers[0].Resources).To(Equal(*df.Spec.Resources))
 			// check args of statefulset

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -303,7 +303,7 @@ func GenerateDragonflyResources(df *resourcesv1.Dragonfly) ([]client.Object, err
 		statefulset.Spec.Template.ObjectMeta.Annotations = df.Spec.Annotations
 	}
 
-	// Apply custom labels to the PVC object and to the pod template
+	// Apply custom labels to the StatefulSet and to the Pod template
 	for key := range df.Spec.Labels {
 		// Make sure we do not overwrite any existing labels
 		if _, ok := statefulset.Spec.Template.ObjectMeta.Labels[key]; !ok {

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -303,10 +303,14 @@ func GenerateDragonflyResources(df *resourcesv1.Dragonfly) ([]client.Object, err
 		statefulset.Spec.Template.ObjectMeta.Annotations = df.Spec.Annotations
 	}
 
+	// Apply custom labels to the PVC object and to the pod template
 	for key := range df.Spec.Labels {
 		// Make sure we do not overwrite any existing labels
 		if _, ok := statefulset.Spec.Template.ObjectMeta.Labels[key]; !ok {
 			statefulset.Spec.Template.ObjectMeta.Labels[key] = df.Spec.Labels[key]
+		}
+		if _, ok := statefulset.Labels[key]; !ok {
+			statefulset.Labels[key] = df.Spec.Labels[key]
 		}
 	}
 

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -6031,7 +6031,7 @@ spec:
               labels:
                 additionalProperties:
                   type: string
-                description: (Optional) Labels to add to the Dragonfly pods.
+                description: (Optional) Labels to add to the Dragonfly pods and StatefulSet.
                 type: object
               memcachedPort:
                 description: (Optional) Dragonfly memcached port

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -6044,7 +6044,7 @@ spec:
               labels:
                 additionalProperties:
                   type: string
-                description: (Optional) Labels to add to the Dragonfly pods.
+                description: (Optional) Labels to add to the Dragonfly pods and StatefulSet.
                 type: object
               memcachedPort:
                 description: (Optional) Dragonfly memcached port


### PR DESCRIPTION
For compliance, it is useful to be able to customize the labels attached to the STS created for any given Dragonfly instance. Till now, it was possible to customize the labels of pods of the STS, but not labels of the STS itself.

I would need help, please, to add tests about this feature. I have searched around in the test code, but I fail (not the tests! they succeed) to understand how to test for a custom label being added to the STS, as well as for label change reconciliation.

I have "manually tested" and in case of custom label change in the values, the STS will be updated, and the pods rolled out (since they too will have to update the label).
