### PR TITLE
chore(dependabot): Added dependabot integration for github actions and go

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
I've looked at the repository and seen that the dependabot integration with GitHub was missing and I've added it for Github Actions and GO.

Because the project is public don't forget to enable the Advanced Security for this repository