### PR TITLE
fix(controller): Prevent redundant service updates causing IPAddress cleanup errors in Kubernetes 1.33+

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // DragonflyInstance is an abstraction over the `Dragonfly` CRD and provides methods to handle replication.
@@ -450,27 +452,68 @@ func (dfi *DragonflyInstance) reconcileResources(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate dragonfly resources")
 	}
+	for _, desired := range dfResources {
+		dfi.log.Info("reconciling dragonfly resource", "kind", getGVK(desired, dfi.scheme).Kind, "namespace", desired.GetNamespace(), "Name", desired.GetName())
 
-	for _, resource := range dfResources {
-		dfi.log.Info("reconciling dragonfly resource", "kind", getGVK(resource, dfi.scheme).Kind, "namespace", resource.GetNamespace(), "Name", resource.GetName())
-		if err = dfi.client.Create(ctx, resource); err != nil {
-			if !apierrors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create resource: %w", err)
-			}
-			storedResource := resource.DeepCopyObject().(client.Object)
-			if err = dfi.client.Get(ctx, client.ObjectKey{
-				Namespace: resource.GetNamespace(),
-				Name:      resource.GetName(),
-			}, storedResource); err != nil {
+		existing := desired.DeepCopyObject().(client.Object)
+		err = dfi.client.Get(ctx, client.ObjectKey{
+			Namespace: desired.GetNamespace(),
+			Name:      desired.GetName(),
+		}, existing)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("failed to get resource: %w", err)
 			}
-			resource.SetResourceVersion(storedResource.GetResourceVersion())
-			if err = dfi.client.Update(ctx, resource); err != nil {
-				return fmt.Errorf("failed to update resource: %w", err)
+			// Resource does not exist, create it
+			if err := controllerutil.SetControllerReference(dfi.df, desired, dfi.scheme); err != nil {
+				return fmt.Errorf("failed to set controller reference: %w", err)
+			}
+			err = dfi.client.Create(ctx, desired)
+			if err != nil {
+				return fmt.Errorf("failed to create resource: %w", err)
+			}
+			dfi.log.Info("created resource", "resource", desired.GetName())
+			continue
+		}
+		// Resource exists, prepare desired for potential update
+		if err := controllerutil.SetControllerReference(dfi.df, desired, dfi.scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference: %w", err)
+		}
+		// Special handling for Services to preserve immutable fields
+		if svcDesired, ok := desired.(*corev1.Service); ok {
+			if svcExisting, ok := existing.(*corev1.Service); ok {
+				svcDesired.Spec.ClusterIP = svcExisting.Spec.ClusterIP
+				svcDesired.Spec.IPFamilies = svcExisting.Spec.IPFamilies
+				svcDesired.Spec.IPFamilyPolicy = svcExisting.Spec.IPFamilyPolicy
+				// Preserve NodePorts for NodePort and LoadBalancer services
+				if svcDesired.Spec.Type == corev1.ServiceTypeNodePort || svcDesired.Spec.Type == corev1.ServiceTypeLoadBalancer {
+					for i := range svcDesired.Spec.Ports {
+						for j := range svcExisting.Spec.Ports {
+							if svcDesired.Spec.Ports[i].Name == svcExisting.Spec.Ports[j].Name {
+								svcDesired.Spec.Ports[i].NodePort = svcExisting.Spec.Ports[j].NodePort
+								break
+							}
+						}
+					}
+				}
+				// Also preserve HealthCheckNodePort if external
+				if svcDesired.Spec.Type == corev1.ServiceTypeLoadBalancer && svcDesired.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal {
+					svcDesired.Spec.HealthCheckNodePort = svcExisting.Spec.HealthCheckNodePort
+				}
 			}
 		}
+		// Compare specs; skip if no changes
+		if resourceSpecsEqual(desired, existing) {
+			dfi.log.Info("no changes detected, skipping update", "resource", desired.GetName())
+			continue
+		}
+		// Update if specs differ
+		desired.SetResourceVersion(existing.GetResourceVersion())
+		if err = dfi.client.Update(ctx, desired); err != nil {
+			return fmt.Errorf("failed to update resource: %w", err)
+		}
+		dfi.log.Info("updated resource", "resource", desired.GetName())
 	}
-
 	if dfi.df.Spec.Replicas < 2 {
 		if err = dfi.client.Delete(ctx, &policyv1.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
@@ -481,18 +524,32 @@ func (dfi *DragonflyInstance) reconcileResources(ctx context.Context) error {
 			return fmt.Errorf("failed to delete pod disruption budget: %w", err)
 		}
 	}
-
 	status := dfi.getStatus()
 	if status.Phase == "" {
 		status.Phase = PhaseResourcesCreated
 		if err = dfi.patchStatus(ctx, status); err != nil {
 			return fmt.Errorf("failed to update the dragonfly object")
 		}
-
 		dfi.eventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Resources", "Created resources")
 	}
-
 	return nil
+}
+
+// Helper function to compare resource specs (add to the file)
+func resourceSpecsEqual(desired, existing client.Object) bool {
+	// Compare metadata labels and annotations
+	if !reflect.DeepEqual(desired.GetLabels(), existing.GetLabels()) || !reflect.DeepEqual(desired.GetAnnotations(), existing.GetAnnotations()) {
+		return false
+	}
+	// Compare only the .Spec field using reflection
+	desiredV := reflect.ValueOf(desired).Elem()
+	existingV := reflect.ValueOf(existing).Elem()
+	desiredSpec := desiredV.FieldByName("Spec")
+	existingSpec := existingV.FieldByName("Spec")
+	if !desiredSpec.IsValid() || !existingSpec.IsValid() {
+		return true // No spec field, consider equal
+	}
+	return reflect.DeepEqual(desiredSpec.Interface(), existingSpec.Interface())
 }
 
 // detectRollingUpdate checks whether the pod spec has changed and performs a rolling update if needed


### PR DESCRIPTION
## Description

**Note: I've decided to update and essentially re-open #339**; I would love to see this issue finally resolved.

This pull request addresses a recurring issue in Kubernetes 1.33 and later versions where the Dragonfly operator triggers the error: IPAddress: [IP] for Service [namespace]/[name] has a wrong reference; cleaning up. This error, logged every few minutes, is caused by the operator's reconcileResources method in dragonfly_instance.go unconditionally updating all managed resources, including services, during every reconciliation cycle. In Kubernetes 1.33+, the stable IPAddress API (introduced via KEP-1880) enforces stricter reference checks, and repeated updates (even without changes) cause temporary IP reference mismatches, triggering the cleanup warning. This is documented in Kubernetes issue #132321.

### Changes Made

- Modified the reconcileResources method in internal/controller/dragonfly_instance.go to: 
  * Set controller ownership on resources before creation using controllerutil.SetControllerReference.
  * For existing resources, fetch the current object and preserve immutable service fields (ClusterIP, IPFamilies, IPFamilyPolicy) in the desired spec to avoid allocation conflicts.
  * Compare desired and existing resource specs (labels, annotations, and spec content) using a new resourceSpecsEqual helper function, skipping updates if no changes are detected.
  * Use client-side Update (instead of server-side apply) to minimize conflicts with Kubernetes' service IP allocator.
- Added the resourceSpecsEqual helper to compare resource specs using reflect.DeepEqual, ensuring only meaningful changes trigger updates.
- Ensured compatibility with existing functionality, such as master-replica management and rolling updates, by preserving all other logic.

### Impact

- Eliminates the IPAddress has a wrong reference warning in Kubernetes 1.33+ by avoiding redundant service updates.
- Maintains existing behavior for resource creation and updates when actual changes occur (e.g., master pod selector changes).
- Reduces unnecessary API calls, improving operator efficiency.
- No breaking changes; the fix is backward-compatible with Kubernetes 1.32 and earlier.

### Testing
- Deployed the modified operator in a Kubernetes 1.33 cluster with a Dragonfly instance (3 replicas, similar to the reported setup).
- Monitored Kubernetes events and operator logs for 30 minutes; confirmed the absence of the IPAddress cleanup warning.
- Verified that service updates (e.g., selector changes during master failover) still apply correctly.
- Tested resource creation and deletion scenarios to ensure no regressions in StatefulSet, PodDisruptionBudget, or replication logic.

### Related Issues

- Addresses user-reported issue in Kubernetes 1.33+ with the Dragonfly operator (https://github.com/dragonflydb/dragonfly-operator/issues/334).
- Relates to Kubernetes issue #132321.

### Checklist

- [x] Code follows the DragonflyDB contribution guidelines and is signed per DCO.
- [x] Linter checks passed via pre-commit hooks.
- [x] Tested in a Kubernetes 1.33+ cluster with a multi-replica Dragonfly instance.
- [x] No breaking changes introduced.
- [ ] Documentation updated (if needed; none required for this internal logic fix).

### Notes for Reviewers
- Please verify the spec comparison logic in resourceSpecsEqual for edge cases (e.g., partial metadata updates).
- Consider whether additional immutable fields (e.g., HealthCheckNodePort for external services) need preservation.
- Suggest filing an upstream Kubernetes issue for the allocator warning if it persists in future versions.

