### PR TITLE
fix(helm): Fix service monitor path

### DIFF
--- a/charts/dragonfly-operator/templates/servicemonitor.yaml
+++ b/charts/dragonfly-operator/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}
-    {{- if .Values.serviceMonitor.telemetryPath }}
+    {{- if .Values.serviceMonitor.path }}
     path: {{ .Values.serviceMonitor.path }}
     {{- end }}
     {{- if .Values.serviceMonitor.timeout }}


### PR DESCRIPTION
Why ?
I noticed my service monitor was not populating correctly in prometheus. I found this non-existent value. I'm not sure it has much of an affect regardless, but figured I'd clean up since I noticed it.