### PR TITLE
feat: allow configuring the default dragonfly version with an env

### DIFF
--- a/internal/resources/version.go
+++ b/internal/resources/version.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package resources
 
-const (
-	Version = "v1.34.1"
-)
+import "os"
+
+var Version = getenv("DRAGONFLY_DEFAULT_VERSION", "v1.34.2")
+
+func getenv(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

This allows configuring the default dragonfly image with an env passed to the operator. If it's blank or not configured, it will fall back to a static string similar to how it's currently operating.