### PR TITLE
fix(operator): do not reconcile resources if dragonfly object is foreground deleted

### DIFF
--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -60,6 +60,11 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("failed to get dragonfly instance: %w", err))
 	}
 
+	if dfi.isTerminating() {
+		// Ignore dragonfly instance that is being foreground deleted
+		return ctrl.Result{}, nil
+	}
+
 	if err = dfi.reconcileResources(ctx); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile dragonfly resources: %w", err)
 	}

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -384,6 +384,11 @@ func (dfi *DragonflyInstance) patchStatus(ctx context.Context, status dfv1alpha1
 	return nil
 }
 
+// isTerminating returns true if the dragonfly instance is being deleted
+func (dfi *DragonflyInstance) isTerminating() bool {
+	return dfi.df.ObjectMeta.DeletionTimestamp != nil
+}
+
 // detectOldMasters checks whether there are any old masters and deletes them
 func (dfi *DragonflyInstance) detectOldMasters(ctx context.Context, updateRevision string) error {
 	var masterPods corev1.PodList


### PR DESCRIPTION
Fixes #408

Testing I went through to make sure the issue is resolved:
```bash
minikube start
kubectl apply -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/manifests/dragonfly-operator.yaml
# wait for opeartor to come up via `kubectl get pods -A`

### BEFORE
kubectl apply -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/config/samples/v1alpha1_dragonfly.yaml
# wait for pods to be ready via `kubectl get pods -A`
kubectl delete --cascade=foreground -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/config/samples/v1alpha1_dragonfly.yaml
# verify deletion is getting stuck via `kubectl get pods -A`, `kubectl get sts -A`. you should see one pod creating and terminating. the delete command should also hang forever

# to delete properly 
kubectl delete -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/config/samples/v1alpha1_dragonfly.yaml

# edit operator image and change the image to the one I just built via `eval $(minikube docker-env) && make docker-build`
kubectl edit deploy -n dragonfly-operator-system dragonfly-operator-controller-manager
# wait for opeartor to come up via `kubectl get pods -A`

### AFTER
kubectl apply -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/config/samples/v1alpha1_dragonfly.yaml
# wait for pods to be ready via `kubectl get pods -A`
kubectl delete --cascade=foreground -f https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/main/config/samples/v1alpha1_dragonfly.yaml   
# verify deletion went through properly via `kubectl get pods -A`, `kubectl get sts -A`. the delete command should also return quickly
