### PR TITLE
feat: df namespace override helm

### DIFF
--- a/charts/dragonfly-operator/templates/_helpers.tpl
+++ b/charts/dragonfly-operator/templates/_helpers.tpl
@@ -74,3 +74,14 @@ Suffix + 48 char fullname = max 63 characters
 {{- define "dragonfly-operator.controllerServiceName" -}}
 {{- printf "%s-controller-svc" (include "dragonfly-operator.fullname" . | trunc 48 | trimSuffix "-" ) -}}
 {{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "dragonfly-operator.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/charts/dragonfly-operator/templates/clusterrolebindings.yaml
+++ b/charts/dragonfly-operator/templates/clusterrolebindings.yaml
@@ -12,7 +12,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "dragonfly-operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "dragonfly-operator.namespace" . }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,4 +29,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "dragonfly-operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "dragonfly-operator.namespace" . }}

--- a/charts/dragonfly-operator/templates/deployment.yaml
+++ b/charts/dragonfly-operator/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
     control-plane: controller-manager
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "dragonfly-operator.namespace" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/dragonfly-operator/templates/grafanadashboards.yaml
+++ b/charts/dragonfly-operator/templates/grafanadashboards.yaml
@@ -17,6 +17,7 @@ items:
       {{- include "dragonfly-operator.labels" $ | nindent 6 }}
       app.kubernetes.io/component: dashboard
     name: {{ printf "dashboard-dragonfly-operator-%s" $dashboardName | trunc 63 | trimSuffix "-"  }}
+    namespace: {{ include "dragonfly-operator.namespace" $ }}
   data:
     {{ $dashboardName }}.json: |-
 {{ $.Files.Get $path | indent 6}}
@@ -32,6 +33,7 @@ metadata:
     {{- include "dragonfly-operator.labels" $ | nindent 4 }}
     app.kubernetes.io/component: dashboard
   name: {{ printf "dragonfly-operator-%s" $dashboardName | trunc 63 | trimSuffix "-" }}
+  namespace: {{ include "dragonfly-operator.namespace" $ }}
 spec:
   allowCrossNamespaceImport: {{ $.Values.grafanaDashboard.grafanaOperator.allowCrossNamespaceImport }}
   folder: {{ $.Values.grafanaDashboard.folder }}

--- a/charts/dragonfly-operator/templates/rolebindings.yaml
+++ b/charts/dragonfly-operator/templates/rolebindings.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "dragonfly-operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,4 +13,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "dragonfly-operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "dragonfly-operator.namespace" . }}

--- a/charts/dragonfly-operator/templates/roles.yaml
+++ b/charts/dragonfly-operator/templates/roles.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "dragonfly-operator.namespace" . }}
 rules:
   - apiGroups:
       - ""

--- a/charts/dragonfly-operator/templates/service.yaml
+++ b/charts/dragonfly-operator/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-rbac-proxy
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "dragonfly-operator.namespace" . }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/dragonfly-operator/templates/serviceaccount.yaml
+++ b/charts/dragonfly-operator/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dragonfly-operator.serviceAccountName" . }}
-  namespace: {{.Release.Namespace | quote}}
+  namespace: {{ include "dragonfly-operator.namespace" . }}
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac

--- a/charts/dragonfly-operator/templates/servicemonitor.yaml
+++ b/charts/dragonfly-operator/templates/servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
   jobLabel: {{ template "dragonfly-operator.fullname" . }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "dragonfly-operator.namespace" . }}
   selector:
     matchLabels:
       {{- include "dragonfly-operator.selectorLabels" . | nindent 6 }}

--- a/charts/dragonfly-operator/templates/tests/test-connection.yaml
+++ b/charts/dragonfly-operator/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "dragonfly-operator.fullname" . }}-test-connection"
+  namespace: {{ include "dragonfly-operator.namespace" . }}
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
   annotations:

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -13,6 +13,7 @@ crds:
 
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 # -- Additional labels to add to all resources
 additionalLabels: {}


### PR DESCRIPTION
Opening PR for solving issue: https://github.com/dragonflydb/dragonfly-operator/issues/403, 

If the user simply wants to install the operator in a custom namespace (e.g., my-ops) instead of default, they do not need any changes to the code. 

They can just run:
`helm install dragonfly-operator ./charts/dragonfly-operator --namespace my-ops --create-namespace`

Since the original code used {{ .Release.Namespace }}, Helm automatically populates that variable with whatever is passed to the --namespace flag.

The reason for `namespaceOverride` files changes and why I had to touch all these files is for Subcharts or GitOps workflows.  If we must support the namespaceOverride value. Helm templates are explicit; we cannot "inject" a namespace into a Deployment manifest without writing the line namespace: {{ ... }} in that file.
If we move the "main" component (the Operator Deployment) to a custom namespace, we must move everything it depends on as well, or the deployment will break.
