### PR TITLE
feat: Upgrade Go to version 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflydb/dragonfly-operator
 
-go 1.24
+go 1.25
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
The dependency updates needs go >=1.25.