### PR TITLE
chore(df): bump default version to v1.36.0

### DIFF
--- a/internal/resources/version.go
+++ b/internal/resources/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package resources
 
 const (
-	Version = "v1.35.0"
+	Version = "v1.36.0"
 )


### PR DESCRIPTION
v1.36.0 is the latest dragonfly version.