### PR TITLE
chore(controller): eliminate redundant redis client connections

### DIFF
--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -59,6 +59,7 @@ func (r *DragonflyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("failed to get dragonfly instance: %w", err))
 	}
+	defer dfi.Close()
 
 	if dfi.isTerminating() {
 		// Ignore dragonfly instance that is being foreground deleted

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -52,6 +52,35 @@ type DragonflyInstance struct {
 	scheme                *runtime.Scheme
 	eventRecorder         record.EventRecorder
 	defaultDragonflyImage string
+	redisClients          map[string]*redis.Client
+}
+
+// getRedisClient returns a cached Redis client for the given pod IP, creating
+// one if it doesn't exist yet. All clients share the same configuration.
+func (dfi *DragonflyInstance) getRedisClient(podIP string) *redis.Client {
+	if dfi.redisClients == nil {
+		dfi.redisClients = make(map[string]*redis.Client)
+	}
+	if c, ok := dfi.redisClients[podIP]; ok {
+		return c
+	}
+	c := redis.NewClient(&redis.Options{
+		ClientName: resources.DragonflyOperatorName,
+		Addr:       net.JoinHostPort(podIP, strconv.Itoa(resources.DragonflyAdminPort)),
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		},
+	})
+	dfi.redisClients[podIP] = c
+	return c
+}
+
+// Close closes all cached Redis clients.
+func (dfi *DragonflyInstance) Close() {
+	for _, c := range dfi.redisClients {
+		c.Close()
+	}
+	dfi.redisClients = nil
 }
 
 // configureReplication configures the given pod as a master and other pods as replicas
@@ -120,14 +149,7 @@ func (dfi *DragonflyInstance) configureReplica(ctx context.Context, pod *corev1.
 
 // checkReplicaRole returns true if the given pod is a replica and is connected to the correct master.
 func (dfi *DragonflyInstance) checkReplicaRole(ctx context.Context, pod *corev1.Pod, masterIp string) (bool, error) {
-	redisClient := redis.NewClient(&redis.Options{
-		ClientName: resources.DragonflyOperatorName,
-		Addr: net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(resources.DragonflyAdminPort)),
-		MaintNotificationsConfig: &maintnotifications.Config{
-			Mode: maintnotifications.ModeDisabled,
-		},
-	})
-	defer redisClient.Close()
+	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
 	resp, err := redisClient.Info(ctx, "replication").Result()
 	if err != nil {
@@ -166,14 +188,7 @@ func (dfi *DragonflyInstance) checkReplicaRole(ctx context.Context, pod *corev1.
 
 // isReplicaStable returns true if the given replica is stable.
 func (dfi *DragonflyInstance) isReplicaStable(ctx context.Context, pod *corev1.Pod) (bool, error) {
-	redisClient := redis.NewClient(&redis.Options{
-		ClientName: resources.DragonflyOperatorName,
-		Addr: net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(resources.DragonflyAdminPort)),
-		MaintNotificationsConfig: &maintnotifications.Config{
-			Mode: maintnotifications.ModeDisabled,
-		},
-	})
-	defer redisClient.Close()
+	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
 	_, err := redisClient.Ping(ctx).Result()
 	if err != nil {
@@ -431,14 +446,7 @@ func (dfi *DragonflyInstance) detectOldMasters(ctx context.Context, updateRevisi
 
 // replicaOf configures the pod as a replica to the given master instance
 func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, masterIp string) error {
-	redisClient := redis.NewClient(&redis.Options{
-		ClientName: resources.DragonflyOperatorName,
-		Addr: net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(resources.DragonflyAdminPort)),
-		MaintNotificationsConfig: &maintnotifications.Config{
-			Mode: maintnotifications.ModeDisabled,
-		},
-	})
-	defer redisClient.Close()
+	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
 	// Determine if we're switching from master to replica, or just pointing to a new master
 	wasMaster, err := dfi.hasMasterRole(ctx, redisClient)
@@ -493,14 +501,7 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 
 // replicaOfNoOne configures the pod as a master along while updating other pods to be replicas
 func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Pod) error {
-	redisClient := redis.NewClient(&redis.Options{
-		ClientName: resources.DragonflyOperatorName,
-		Addr: net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(resources.DragonflyAdminPort)),
-		MaintNotificationsConfig: &maintnotifications.Config{
-			Mode: maintnotifications.ModeDisabled,
-		},
-	})
-	defer redisClient.Close()
+	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
 	dfi.log.Info("running SLAVE OF NO ONE command", "pod", pod.Name, "addr", redisClient.Options().Addr)
 	resp, err := redisClient.SlaveOf(ctx, "NO", "ONE").Result()
@@ -717,11 +718,7 @@ func (dfi *DragonflyInstance) isDatasetLoaded(ctx context.Context, pod *corev1.P
 		return false, nil
 	}
 
-	redisClient := redis.NewClient(&redis.Options{
-		ClientName: resources.DragonflyOperatorName,
-		Addr: net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(resources.DragonflyAdminPort)),
-	})
-	defer redisClient.Close()
+	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
 	persistenceInfo, err := redisClient.Info(ctx, "persistence").Result()
 	if err != nil {
@@ -937,14 +934,7 @@ func (dfi *DragonflyInstance) updatedMaster(ctx context.Context, oldMaster *core
 func (dfi *DragonflyInstance) replTakeover(ctx context.Context, newMaster *corev1.Pod, oldMaster *corev1.Pod) error {
 	dfi.log.Info("running REPLTAKEOVER on replica", "pod", newMaster.Name)
 
-	redisClient := redis.NewClient(&redis.Options{
-		ClientName: resources.DragonflyOperatorName,
-		Addr: net.JoinHostPort(newMaster.Status.PodIP, strconv.Itoa(resources.DragonflyAdminPort)),
-		MaintNotificationsConfig: &maintnotifications.Config{
-			Mode: maintnotifications.ModeDisabled,
-		},
-	})
-	defer redisClient.Close()
+	redisClient := dfi.getRedisClient(newMaster.Status.PodIP)
 
 	resp, err := redisClient.Do(ctx, "repltakeover", "10000").Result()
 	if err != nil {

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -67,6 +67,7 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("failed to get dragonfly instance: %w", err))
 	}
+	defer dfi.Close()
 
 	podReady, readinessErr := dfi.isPodReady(ctx, &pod)
 	if readinessErr != nil {


### PR DESCRIPTION
Adding an update to eliminate redundant Redis client connections per reconcile loop.

Each reconciliation cycle was creating and tearing down multiple Redis client connections to the same pod IPs (e.g. in checkReplicaRole, isReplicaStable, replicaOf, replicaOfNoOne etc.). 

This adds unnecessary connection overhead and latency, especially in clusters with many replicas where several of these methods are called in sequence for the same pod.