### PR TITLE
chore(helm): allow overriding grafanaDashboard instanceSelector match…

### DIFF
--- a/charts/dragonfly-operator/templates/grafanadashboards.yaml
+++ b/charts/dragonfly-operator/templates/grafanadashboards.yaml
@@ -39,7 +39,11 @@ spec:
   folder: {{ $.Values.grafanaDashboard.folder }}
   instanceSelector:
     matchLabels:
+      {{- if $.Values.grafanaDashboard.grafanaOperator.matchLabels }}
       {{- toYaml $.Values.grafanaDashboard.grafanaOperator.matchLabels | nindent 6 }}
+      {{- else }}
+      dashboards: grafana
+      {{- end }}
   configMapRef:
     name: {{ printf "dashboard-dragonfly-operator-%s" $dashboardName | trunc 63 | trimSuffix "-" }}
     key: {{ $dashboardName }}.json

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -196,5 +196,4 @@ grafanaDashboard:
     enabled: false
     allowCrossNamespaceImport: true
     # -- Selected labels for Grafana instance
-    matchLabels:
-      dashboards: grafana
+    matchLabels: {}


### PR DESCRIPTION
Fixes an issue where user-provided grafanaDashboard.grafanaOperator.matchLabels values were deep-merged with the chart default (dashboards: grafana) instead of replacing it, causing grafana-operator to reject the dashboard since all selector labels must match.

Existing users who do not set matchLabels will continue to get the same default behavior (dashboards: grafana).
