### PR TITLE
feat(helm): add annotations support for operator service

### DIFF
--- a/charts/dragonfly-operator/templates/service.yaml
+++ b/charts/dragonfly-operator/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-rbac-proxy
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespace: {{ include "dragonfly-operator.namespace" . }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -51,6 +51,8 @@ podSecurityContext:
   runAsNonRoot: true
 
 service:
+  # Annotations to add to the operator Service
+  annotations: {}
   type: ClusterIP
   port: 8443
   metricsPort: 8080


### PR DESCRIPTION
## Summary

Add Helm support for configuring annotations on the operator Service for deployments that scrape metrics without the RBAC proxy.

## Motivation

The Helm chart currently does not provide a way to configure annotations on the operator Service through values. In environments where Prometheus service discovery relies on Kubernetes Service annotations, this forces users to patch `dragonfly-operator-controller-svc` manually after deployment.

This is primarily useful in deployments where `rbacProxy.enabled` is disabled and Prometheus relies on Kubernetes Service annotations for discovery. The change does not alter the default proxy-based metrics exposure behaviour.

## Changes

- add `service.annotations` to `charts/dragonfly-operator/values.yaml`
- render `metadata.annotations` in `charts/dragonfly-operator/templates/service.yaml` when provided

## Example

```yaml
rbacProxy:
  enabled: false

service:
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "8080"
    prometheus.io/path: /metrics
```