### PR TITLE
fix: permissions for enableReplicationReadinessGate

### DIFF
--- a/charts/dragonfly-operator/templates/clusterroles.yaml
+++ b/charts/dragonfly-operator/templates/clusterroles.yaml
@@ -29,6 +29,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
       - services
     verbs:
       - create


### PR DESCRIPTION
#467 did not update roles manifests for the helm chart