### PR TITLE
fix(e2e): wait for PhaseReady before accessing master pod

### DIFF
--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -714,8 +714,8 @@ var _ = Describe("Dragonfly tiering test with single replica", Ordered, FlakeAtt
 		})
 
 		It("Resources should exist", func() {
-			// Wait until Dragonfly object is marked initialized
-			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseResourcesCreated, 2*time.Minute)
+			// Wait until Dragonfly object is marked initialized and master is elected
+			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
 
 			// Check for service and statefulset
@@ -833,8 +833,8 @@ var _ = Describe("Dragonfly PVC Test with single replica", Ordered, FlakeAttempt
 		})
 
 		It("Resources should exist", func() {
-			// Wait until Dragonfly object is marked initialized
-			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseResourcesCreated, 2*time.Minute)
+			// Wait until Dragonfly object is marked initialized and master is elected
+			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
 
 			// Check for service and statefulset
@@ -888,6 +888,10 @@ var _ = Describe("Dragonfly PVC Test with single replica", Ordered, FlakeAttempt
 			// Wait until Dragonfly object is marked initialized
 			waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)
 			waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)
+			// Phase may already be Ready from before deletion; wait explicitly for the
+			// lifecycle controller to finish master election on the recreated pod.
+			err = waitForMasterPod(ctx, k8sClient, name, namespace, 2*time.Minute)
+			Expect(err).To(BeNil())
 			// check if the pod is created
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      fmt.Sprintf("%s-0", name),

--- a/e2e/util.go
+++ b/e2e/util.go
@@ -66,6 +66,28 @@ func parseTieredEntriesFromInfo(info string) (int64, error) {
 	return 0, fmt.Errorf("tiered_entries not found")
 }
 
+// waitForMasterPod polls until at least one pod with role=master exists. Use this
+// after waitForStatefulSetReady to guarantee the lifecycle controller has finished
+// master election before the test tries to connect.
+func waitForMasterPod(ctx context.Context, c client.Client, name, namespace string, maxDuration time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, maxDuration)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for master pod for %s", name)
+		default:
+			var pods corev1.PodList
+			if err := c.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
+				resources.DragonflyNameLabelKey: name,
+				resources.RoleLabelKey:          resources.Master,
+			}); err == nil && len(pods.Items) > 0 {
+				return nil
+			}
+		}
+	}
+}
+
 func waitForStatefulSetReady(ctx context.Context, c client.Client, name, namespace string, maxDuration time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, maxDuration)
 	defer cancel()


### PR DESCRIPTION
Single-replica tests waited on PhaseResourcesCreated, which is set before the lifecycle controller runs configureReplication and labels the master pod, racing checkAndK8sPortForwardRedis with master election and intermittently failing with "no master pod found".

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->