### PR TITLE
fix(make): use server side apply to avoid hitting annotation max limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
 
 .PHONY: generate-manifests
 generate-manifests: manifests kustomize ## Generate manifests e.g. CRD, RBAC etc.
@@ -126,7 +126,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | kubectl apply --server-side -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
Client side kubectl apply tries to fit the last configured state of the dragonfly crd in an annotation. This makes the apply fail as annotation hits max limit.