### PR TITLE
fix(controller): ignore immutable field modifications for statefulset

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -647,6 +647,25 @@ func (dfi *DragonflyInstance) reconcileResources(ctx context.Context) error {
 		if err := controllerutil.SetControllerReference(dfi.df, desired, dfi.scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference: %w", err)
 		}
+		// Special handling for StatefulSets to preserve immutable fields.
+		// VolumeClaimTemplates, Selector, ServiceName, and PodManagementPolicy
+		// cannot be changed after creation. Copy them from existing so they
+		// never appear as a diff. If the user changes e.g. persistentVolumeClaimSpec,
+		// the change is silently dropped here — a delete+recreate is required.
+		if stsDesired, ok := desired.(*appsv1.StatefulSet); ok {
+			if stsExisting, ok := existing.(*appsv1.StatefulSet); ok {
+				if !reflect.DeepEqual(stsDesired.Spec.VolumeClaimTemplates, stsExisting.Spec.VolumeClaimTemplates) {
+					dfi.log.Info("VolumeClaimTemplates change detected but cannot be applied to an existing StatefulSet; delete and recreate the Dragonfly instance to change PVC configuration",
+						"resource", stsDesired.Name)
+					dfi.eventRecorder.Event(dfi.df, corev1.EventTypeWarning, "ImmutableField",
+						"VolumeClaimTemplates change ignored: delete and recreate the Dragonfly instance to apply PVC configuration changes")
+				}
+				stsDesired.Spec.VolumeClaimTemplates = stsExisting.Spec.VolumeClaimTemplates
+				stsDesired.Spec.Selector = stsExisting.Spec.Selector
+				stsDesired.Spec.ServiceName = stsExisting.Spec.ServiceName
+				stsDesired.Spec.PodManagementPolicy = stsExisting.Spec.PodManagementPolicy
+			}
+		}
 		// Special handling for Services to preserve immutable fields
 		if svcDesired, ok := desired.(*corev1.Service); ok {
 			if svcExisting, ok := existing.(*corev1.Service); ok {


### PR DESCRIPTION
Statefulset has some fields that are immutable e.g. volumeClaims. Any attempt to update these fields would fail causing the controller to be stuck in update state. Ignore these fields when update to the desired state. The controller will throw warnings if user tries to update immutable fields.

Note, this PR doesn't create a new statefulset to update the immutable fields. I think it would best to leave it for users to create a new Dragonfly resource with updated pvcs etc. i.e. making it behave identically with statefulset. Allowing updating these fields would need sts deletion, handling orphan pods etc. Manual handling of such cases makes more sense to me than by the dragonfly operator.