### PR TITLE
fix(e2e): improve tiering test

### DIFF
--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -750,28 +750,30 @@ var _ = Describe("Dragonfly tiering test with single replica", Ordered, FlakeAtt
 			defer close(stopChan)
 			defer rc.Close()
 
+			// Clean residual data from prior FlakeAttempts retries.
+			Expect(rc.FlushAll(ctx).Err()).To(BeNil())
+
+			// FlushAll deletes keys but tiered_entries updates asynchronously,
+			// so wait until it reaches zero before inserting our test key.
+			Eventually(func() int64 {
+				info, _ := rc.Info(ctx, "tiered").Result()
+				n, _ := parseTieredEntriesFromInfo(info)
+				return n
+			}, 10*time.Second, 200*time.Millisecond).Should(Equal(int64(0)))
+
 			// Insert BIG value (>64B so it is eligible for tiering)
 			const size = 1 << 20 // 1 MiB
 			payload := make([]byte, size)
 			_, _ = rand.Read(payload)
 
-			infoStr, err := rc.Info(ctx, "tiered").Result()
-			Expect(err).To(BeNil())
-
-			entries, err := parseTieredEntriesFromInfo(infoStr)
-			Expect(err).To(BeNil())
-			Expect(entries).To(Equal(int64(0))) // make sure this matches your expectation
-
 			Expect(rc.Set(ctx, "foo", payload, 0).Err()).To(BeNil())
 
-			// Inserted one big key, tiered entries should be 1
-			infoStr, err = rc.Info(ctx, "tiered").Result()
-			Expect(err).To(BeNil())
-
-			fmt.Println("Tiered entried Info: ", infoStr)
-			entries, err = parseTieredEntriesFromInfo(infoStr)
-			Expect(err).To(BeNil())
-			Expect(entries).To(Equal(int64(1))) // make sure this matches your expectation
+			// Stash is async, poll until the value is tiered.
+			Eventually(func() int64 {
+				info, _ := rc.Info(ctx, "tiered").Result()
+				n, _ := parseTieredEntriesFromInfo(info)
+				return n
+			}, 30*time.Second, 200*time.Millisecond).Should(Equal(int64(1)))
 
 			// Fetch and compare by size
 			data, err := rc.Get(ctx, "foo").Bytes()


### PR DESCRIPTION
tiering e2e test flakes because `tiered_entries` counter updates asynchronously

poll with `Eventually` instead of asserting immediately

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->