### PR TITLE
feat(monitoring): re-order filter variables to improve grafana dashboard user experience

### DIFF
--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1467,15 +1467,15 @@
 			"type": "prometheus",
 			"uid": "${DS_PROMETHEUS}"
 		  },
-		  "definition": "label_values(dragonfly_uptime_in_seconds,app)",
+		  "definition": "label_values(dragonfly_uptime_in_seconds,namespace)",
 		  "hide": 0,
 		  "includeAll": false,
-		  "label": "dragonfly",
+		  "label": "namespace",
 		  "multi": false,
-		  "name": "Dragonfly",
+		  "name": "namespace",
 		  "options": [],
 		  "query": {
-			"query": "label_values(dragonfly_uptime_in_seconds,app)",
+			"query": "label_values(dragonfly_uptime_in_seconds,namespace)",
 			"refId": "PrometheusVariableQueryEditor-VariableQuery"
 		  },
 		  "refresh": 1,
@@ -1490,15 +1490,15 @@
 			"type": "prometheus",
 			"uid": "${DS_PROMETHEUS}"
 		  },
-		  "definition": "label_values(dragonfly_uptime_in_seconds{app=\"$Dragonfly\"},namespace)",
+		  "definition": "label_values(dragonfly_uptime_in_seconds{namespace=\"$namespace\"},app)",
 		  "hide": 0,
 		  "includeAll": false,
-		  "label": "namespace",
+		  "label": "dragonfly",
 		  "multi": false,
-		  "name": "namespace",
+		  "name": "Dragonfly",
 		  "options": [],
 		  "query": {
-			"query": "label_values(dragonfly_uptime_in_seconds{app=\"$Dragonfly\"},namespace)",
+			"query": "label_values(dragonfly_uptime_in_seconds{namespace=\"$namespace\"},app)",
 			"refId": "PrometheusVariableQueryEditor-VariableQuery"
 		  },
 		  "refresh": 1,


### PR DESCRIPTION
This PR reorders the `namespace` and `dragonfly` inputs in the Grafana dashboard, and changes their filters to allign with the usual separation by namespace in Kubernetes.

Before:
<img width="742" height="178" alt="2026-04-30-15:36:47" src="https://github.com/user-attachments/assets/07c3a005-f0d7-49df-9163-29a03d63771e" />

All Dragonfly instances are listed, which can make the list quite convoluted if, e.g. many dev environments with their own Dragonfly instance exist, separated by team/project namespace.

After:
<img width="809" height="143" alt="2026-04-30-15:34:22" src="https://github.com/user-attachments/assets/cb627f1c-a635-47cf-a22e-b72cb1f05bfc" />

<img width="783" height="136" alt="2026-04-30-15:35:54" src="https://github.com/user-attachments/assets/5ef29b3d-9507-4dcb-a93d-549fbbcce64a" />

Since you usually know which namespace's metrics you want to look at, now all namespaces with Dragonfly statefulsets are listed in `namespace`. Upon selecting the desired namespace, the `dragonfly` input shows all Dragonfly statefulsets in the selected namespace.

This follows the Kubernetes logic of namespace -> statefulset -> pod and is in my opinion more streamlined and easier to use.