### PR TITLE
fix(controller): pod role label updates

### DIFF
--- a/e2e/dragonfly_role_label_loading_test.go
+++ b/e2e/dragonfly_role_label_loading_test.go
@@ -1,0 +1,410 @@
+/*
+Copyright 2023 DragonflyDB authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	resourcesv1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
+	"github.com/dragonflydb/dragonfly-operator/internal/controller"
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// This suite guards the fix for role-label reconciliation during dataset
+// loads: a pod whose Dragonfly admin socket is reachable must (re)gain its
+// role=replica label immediately, even while the dataset is still loading and
+// the pod is therefore not "ready" by the operator's stricter dataset-loaded
+// check. Before the fix, the pod lifecycle reconciler returned early on
+// !podReady, so loading pods stayed unlabeled until loading completed.
+//
+// The Dragonfly instance is intentionally CPU-constrained and seeded with a
+// large keyspace so that a restarted pod spends an observable amount of time
+// in the loading state (snapshot load followed by a full sync).
+var _ = Describe("Dragonfly Role Label Recovery While Loading", Ordered, FlakeAttempts(3), func() {
+	ctx := context.Background()
+	name := "df-loading-label-test"
+	namespace := "default"
+
+	const (
+		seedChunks        = 5
+		keysPerChunk      = 200000
+		seedValueSizeArg  = "128"
+		samplingInterval  = 300 * time.Millisecond
+		missedWindowLimit = 5
+	)
+
+	Context("Role label is reconciled while the dataset is loading", func() {
+		BeforeAll(func() {
+			// Clean up any existing resource from previous test runs
+			var df resourcesv1.Dragonfly
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, &df)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).To(BeNil(), "unexpected error getting Dragonfly resource")
+			Expect(k8sClient.Delete(ctx, &df)).To(Succeed(), "failed to delete existing Dragonfly resource")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      name,
+					Namespace: namespace,
+				}, &df)
+				return apierrors.IsNotFound(err)
+			}, 1*time.Minute, 2*time.Second).Should(BeTrue(), "existing resource should be deleted")
+		})
+
+		It("Should create a CPU-constrained Dragonfly with snapshot persistence", func() {
+			err := k8sClient.Create(ctx, &resourcesv1.Dragonfly{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: resourcesv1.DragonflySpec{
+					Replicas: 2,
+					// The readiness gate keeps PodReady=False until the
+					// replica reaches a stable sync, which lets this test
+					// assert that PodReady is still blocked while the role
+					// label is already reconciled.
+					EnableReplicationReadinessGate: true,
+					// Throttle the CPU so snapshot loading and full syncs
+					// take long enough to be observable from the test.
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("150m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("150m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+					Snapshot: &resourcesv1.Snapshot{
+						Cron: "*/1 * * * *",
+						PersistentVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{
+								corev1.ReadWriteOnce,
+							},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).To(BeNil())
+
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseResourcesCreated, 3*time.Minute)).
+				To(Succeed(), "Dragonfly should reach PhaseResourcesCreated")
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 5*time.Minute)).
+				To(Succeed(), "Dragonfly should reach PhaseReady")
+			Expect(waitForStatefulSetReady(ctx, k8sClient, name, namespace, 5*time.Minute)).
+				To(Succeed(), "StatefulSet should become ready")
+		})
+
+		It("Should seed a dataset large enough to produce a visible load window", func() {
+			Expect(waitForMasterPod(ctx, k8sClient, name, namespace, 2*time.Minute)).To(Succeed())
+
+			var masterPods corev1.PodList
+			Expect(k8sClient.List(ctx, &masterPods, client.InNamespace(namespace), client.MatchingLabels{
+				resources.DragonflyNameLabelKey: name,
+				resources.RoleLabelKey:          resources.Master,
+			})).To(Succeed())
+			Expect(masterPods.Items).To(HaveLen(1), "exactly one master pod should exist")
+
+			pf, err := setupPortForwardWithCleanup(ctx, clientset, cfg, &masterPods.Items[0], resources.DragonflyPort, 30*time.Second)
+			Expect(err).To(BeNil())
+			defer pf.Cleanup()
+
+			// DEBUG POPULATE generates the keys server side, but the
+			// CPU-throttled instance needs a while per chunk, hence the
+			// generous timeouts.
+			rc := redis.NewClient(&redis.Options{
+				Addr:                  fmt.Sprintf("localhost:%d", pf.LocalPort),
+				DialTimeout:           15 * time.Second,
+				ReadTimeout:           2 * time.Minute,
+				WriteTimeout:          30 * time.Second,
+				ContextTimeoutEnabled: true,
+			})
+			defer rc.Close()
+
+			for i := 0; i < seedChunks; i++ {
+				err := rc.Do(ctx, "DEBUG", "POPULATE", keysPerChunk, fmt.Sprintf("chunk%d-", i), seedValueSizeArg).Err()
+				Expect(err).To(BeNil(), "DEBUG POPULATE chunk %d should succeed", i)
+			}
+
+			dbSize, err := rc.DBSize(ctx).Result()
+			Expect(err).To(BeNil())
+			Expect(dbSize).To(BeNumerically(">=", int64(seedChunks*keysPerChunk)), "master should hold the seeded keys")
+			GinkgoLogr.Info("Dataset seeded", "keys", dbSize)
+
+			// The snapshot cron fires every minute (on both master and
+			// replica); waiting a bit longer than one full cycle guarantees
+			// every pod has persisted the seeded dataset to its PVC.
+			time.Sleep(75 * time.Second)
+		})
+
+		It("Should reapply role=replica while the dataset is still loading", func() {
+			// Make sure the cluster is settled before disturbing it. This also
+			// lets flake retries of this spec start from a clean state.
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 5*time.Minute)).To(Succeed())
+			Expect(waitForStatefulSetReady(ctx, k8sClient, name, namespace, 5*time.Minute)).To(Succeed())
+
+			var replicaPods corev1.PodList
+			Expect(k8sClient.List(ctx, &replicaPods, client.InNamespace(namespace), client.MatchingLabels{
+				resources.DragonflyNameLabelKey:    name,
+				resources.KubernetesPartOfLabelKey: "dragonfly",
+				resources.RoleLabelKey:             resources.Replica,
+			})).To(Succeed())
+			Expect(replicaPods.Items).NotTo(BeEmpty(), "a replica pod should exist")
+
+			target := replicaPods.Items[0]
+			podName := target.Name
+			podKey := types.NamespacedName{Name: podName, Namespace: namespace}
+			oldUID := target.UID
+
+			// Restart the replica. The recreated pod finds the persisted
+			// snapshot on its PVC and goes through a real dataset-load window
+			// (snapshot load, then a full sync once SLAVE OF is accepted).
+			Expect(k8sClient.Delete(ctx, &target)).To(Succeed())
+
+			// Wait until the new pod is Running and its dragonfly container is
+			// ready, i.e. the admin socket is reachable. This mirrors the
+			// operator's isReachable() gate and is intentionally weaker than
+			// its dataset-loaded readiness check.
+			var restarted corev1.Pod
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, podKey, &restarted); err != nil {
+					return err
+				}
+				if restarted.UID == oldUID {
+					return fmt.Errorf("pod %s not recreated yet", podName)
+				}
+				if restarted.Status.Phase != corev1.PodRunning {
+					return fmt.Errorf("pod %s not running yet (phase: %s)", podName, restarted.Status.Phase)
+				}
+				if !dragonflyContainerIsReady(&restarted) {
+					return fmt.Errorf("dragonfly container in pod %s not ready yet", podName)
+				}
+				return nil
+			}, 3*time.Minute, 1*time.Second).Should(Succeed())
+
+			// Keep a single port-forward to the admin port so the loading
+			// state can be sampled at high frequency.
+			pf, err := setupPortForwardWithCleanup(ctx, clientset, cfg, &restarted, resources.DragonflyAdminPort, 30*time.Second)
+			Expect(err).To(BeNil())
+			defer pf.Cleanup()
+
+			adminClient := redis.NewClient(&redis.Options{
+				Addr:                  fmt.Sprintf("localhost:%d", pf.LocalPort),
+				DialTimeout:           5 * time.Second,
+				ReadTimeout:           5 * time.Second,
+				WriteTimeout:          5 * time.Second,
+				ContextTimeoutEnabled: true,
+			})
+			defer adminClient.Close()
+
+			sampleLoading := func() (bool, error) {
+				infoCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				info, err := adminClient.Info(infoCtx, "persistence").Result()
+				if err != nil {
+					return false, err
+				}
+				loading, loadState := parseLoadingInfo(info)
+				return isDatasetLoading(loading, loadState), nil
+			}
+
+			// Step 1 — assert the intermediate state the fix creates: the pod
+			// gets role=replica while INFO persistence still reports the
+			// dataset as loading. The pre-fix reconciler returned early on
+			// !podReady, so a loading pod stayed unlabeled until loading
+			// completed — which the final-state checks of the other dataset
+			// loading test cannot detect.
+			observedRoleWhileLoading := false
+			podReadyDuringWindow := corev1.ConditionUnknown
+			missedWindowStreak := 0
+
+			deadline := time.Now().Add(4 * time.Minute)
+			for time.Now().Before(deadline) {
+				stillLoading, err := sampleLoading()
+				if err != nil {
+					// Transient connection hiccup; retry.
+					time.Sleep(samplingInterval)
+					continue
+				}
+
+				var pod corev1.Pod
+				if err := k8sClient.Get(ctx, podKey, &pod); err != nil {
+					time.Sleep(samplingInterval)
+					continue
+				}
+
+				if role, hasRole := pod.Labels[resources.RoleLabelKey]; hasRole {
+					if stillLoading {
+						Expect(role).To(Equal(resources.Replica), "restarted pod should be labeled as replica")
+						podReadyDuringWindow = podCondition(&pod, corev1.PodReady)
+						observedRoleWhileLoading = true
+						break
+					}
+					// The label is present but no load is in progress. There
+					// can be a short gap between the initial snapshot load and
+					// the full sync that follows SLAVE OF, so tolerate a few
+					// samples before concluding the window was missed.
+					missedWindowStreak++
+					if missedWindowStreak >= missedWindowLimit {
+						break
+					}
+				} else {
+					missedWindowStreak = 0
+				}
+
+				time.Sleep(samplingInterval)
+			}
+
+			Expect(observedRoleWhileLoading).To(BeTrue(),
+				"pod should be labeled role=replica while the dataset is still loading; with the old behavior loading pods stayed unlabeled until loading completed")
+
+			// While the dataset is loading the pod must not be PodReady: the
+			// replication-ready readiness gate only opens once the replica
+			// reaches a stable sync, which requires loading to have finished.
+			Expect(podReadyDuringWindow).NotTo(Equal(corev1.ConditionTrue),
+				"PodReady must still be blocked by the readiness gate while the dataset is loading")
+
+			// Step 2 — simulate a lost label patch (e.g. a transient API
+			// outage) inside the load window and verify the operator restores
+			// the label without waiting for loading to complete.
+			var podToStrip corev1.Pod
+			Expect(k8sClient.Get(ctx, podKey, &podToStrip)).To(Succeed())
+			stripPatch := client.MergeFrom(podToStrip.DeepCopy())
+			delete(podToStrip.Labels, resources.RoleLabelKey)
+			Expect(k8sClient.Patch(ctx, &podToStrip, stripPatch)).To(Succeed())
+
+			restored := false
+			restoredWhileLoading := false
+			deadline = time.Now().Add(2 * time.Minute)
+			for time.Now().Before(deadline) {
+				stillLoading, err := sampleLoading()
+				if err != nil {
+					time.Sleep(samplingInterval)
+					continue
+				}
+
+				var pod corev1.Pod
+				if err := k8sClient.Get(ctx, podKey, &pod); err != nil {
+					time.Sleep(samplingInterval)
+					continue
+				}
+
+				if role, hasRole := pod.Labels[resources.RoleLabelKey]; hasRole {
+					Expect(role).To(Equal(resources.Replica), "restored label should be role=replica")
+					restored = true
+					restoredWhileLoading = stillLoading
+					break
+				}
+
+				if !stillLoading {
+					// The load window closed before the operator restored the
+					// label; the assertions below will fail and report it.
+					break
+				}
+
+				time.Sleep(samplingInterval)
+			}
+
+			Expect(restored).To(BeTrue(), "operator should restore a stripped role label")
+			Expect(restoredWhileLoading).To(BeTrue(),
+				"the role label must be restored while the dataset is still loading, not only after loading completes")
+
+			// Step 3 — everything converges once loading completes: the
+			// replica keeps its label, reaches a stable sync so the readiness
+			// gate opens, and the cluster reports Ready again.
+			Eventually(func() error {
+				var pod corev1.Pod
+				if err := k8sClient.Get(ctx, podKey, &pod); err != nil {
+					return err
+				}
+				if pod.Labels[resources.RoleLabelKey] != resources.Replica {
+					return fmt.Errorf("pod %s lost its replica role label", podName)
+				}
+				if podCondition(&pod, corev1.PodReady) != corev1.ConditionTrue {
+					return fmt.Errorf("pod %s is not PodReady yet", podName)
+				}
+				return nil
+			}, 5*time.Minute, 2*time.Second).Should(Succeed(), "replica should become PodReady with its role label after loading completes")
+
+			Expect(waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)).To(Succeed())
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			var df resourcesv1.Dragonfly
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, &df)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).To(BeNil(), "unexpected error getting Dragonfly resource during cleanup")
+			Expect(k8sClient.Delete(ctx, &df)).To(Succeed(), "failed to delete Dragonfly resource during cleanup")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      name,
+					Namespace: namespace,
+				}, &df)
+				return apierrors.IsNotFound(err)
+			}, 1*time.Minute, 2*time.Second).Should(BeTrue(), "resource should be deleted")
+		})
+	})
+})
+
+// dragonflyContainerIsReady returns true if the dragonfly container of the pod
+// passes its readiness probe.
+func dragonflyContainerIsReady(pod *corev1.Pod) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == resources.DragonflyContainerName {
+			return cs.Ready
+		}
+	}
+	return false
+}
+
+// podCondition returns the status of the given pod condition, or
+// ConditionUnknown when the condition is absent.
+func podCondition(pod *corev1.Pod, condType corev1.PodConditionType) corev1.ConditionStatus {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == condType {
+			return c.Status
+		}
+	}
+	return corev1.ConditionUnknown
+}

--- a/e2e/util.go
+++ b/e2e/util.go
@@ -244,16 +244,19 @@ func setupPortForwardWithCleanup(ctx context.Context, clientset *kubernetes.Clie
 		return nil, fmt.Errorf("pod %s/%s is not running (phase: %s)", pod.Namespace, pod.Name, pod.Status.Phase)
 	}
 
-	// Verify pod has Ready condition
+	// Verify pod has ContainersReady condition. PodReady is intentionally not
+	// used here: pods with custom readiness gates (e.g. the replication-ready
+	// gate) are connectable long before PodReady turns true, and tests need to
+	// inspect pods exactly in that window.
 	hasReadyCondition := false
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+		if condition.Type == corev1.ContainersReady && condition.Status == corev1.ConditionTrue {
 			hasReadyCondition = true
 			break
 		}
 	}
 	if !hasReadyCondition {
-		return nil, fmt.Errorf("pod %s/%s is not ready (Ready condition not true)", pod.Namespace, pod.Name)
+		return nil, fmt.Errorf("pod %s/%s is not ready (ContainersReady condition not true)", pod.Namespace, pod.Name)
 	}
 
 	// Verify the Dragonfly container is ready
@@ -476,7 +479,11 @@ func tryCheckPersistenceInfo(ctx context.Context, clientset *kubernetes.Clientse
 		return "", "", fmt.Errorf("unable to get persistence info: %w", err)
 	}
 
-	// Parse info output
+	loading, loadState = parseLoadingInfo(info)
+	return loading, loadState, nil
+}
+
+func parseLoadingInfo(info string) (loading string, loadState string) {
 	sc := bufio.NewScanner(strings.NewReader(info))
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
@@ -496,5 +503,18 @@ func tryCheckPersistenceInfo(ctx context.Context, clientset *kubernetes.Clientse
 		}
 	}
 
-	return loading, loadState, sc.Err()
+	return loading, loadState
+}
+
+// isDatasetLoading mirrors the operator's isDatasetLoaded check: the dataset is
+// considered loading when INFO persistence reports loading != 0 or a
+// load_state other than done (both snapshot loads and full syncs set these).
+func isDatasetLoading(loading, loadState string) bool {
+	if loading != "" && loading != "0" {
+		return true
+	}
+	if loadState != "" && loadState != "done" {
+		return true
+	}
+	return false
 }

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -92,7 +92,7 @@ func (dfi *DragonflyInstance) Close() {
 
 // patchPodMetadata patches a pod's labels/annotations with retry-on-conflict.
 func (dfi *DragonflyInstance) patchPodMetadata(ctx context.Context, podKey types.NamespacedName, mutate func(*corev1.Pod)) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var pod corev1.Pod
 		if err := dfi.client.Get(ctx, podKey, &pod); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -102,7 +102,7 @@ func (dfi *DragonflyInstance) patchPodMetadata(ctx context.Context, podKey types
 			return err
 		}
 
-		patch := client.MergeFrom(pod.DeepCopy())
+		patch := client.MergeFromWithOptions(pod.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		if pod.Labels == nil {
 			pod.Labels = map[string]string{}
 		}
@@ -215,6 +215,8 @@ func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *co
 			p.Annotations[resources.MasterIpAnnotationKey] = sanitized
 			if ip := net.ParseIP(sanitized); ip != nil && ip.To4() != nil {
 				p.Labels[resources.MasterIpLabelKey] = sanitized
+        } else {
+          delete(p.Labels, resources.MasterIpLabelKey)
 			}
 		})
 	}
@@ -337,7 +339,7 @@ func (dfi *DragonflyInstance) checkAndConfigureReplicas(ctx context.Context, mas
 			}
 		}
 
-		// Label unlabeled pods even while loading a snapshot.
+		// Configure (SLAVE OF) and label unlabeled pods even while loading a snapshot.
 		if !roleExists(&pod) && isReachable(&pod) {
 			if err := dfi.configureReplica(ctx, &pod, masterIp); err != nil {
 				return err

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -570,7 +570,6 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 	return nil
 }
 
-
 // replicaOfNoOne configures the pod as a master along while updating other pods to be replicas
 func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Pod) error {
 	redisClient := dfi.getRedisClient(pod.Status.PodIP)

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -91,11 +91,6 @@ func (dfi *DragonflyInstance) Close() {
 }
 
 // patchPodMetadata patches a pod's labels/annotations with retry-on-conflict.
-// Re-GETs the pod inside the retry loop to avoid stale-resourceVersion 409s
-// from concurrent kubelet status writes. NotFound is treated as success so
-// the caller stays idempotent when the pod was deleted between the Redis
-// command and the label update. The mutate callback runs on a fresh pod and
-// must not call the k8s client.
 func (dfi *DragonflyInstance) patchPodMetadata(ctx context.Context, podKey types.NamespacedName, mutate func(*corev1.Pod)) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var pod corev1.Pod
@@ -164,15 +159,14 @@ func (dfi *DragonflyInstance) configureReplication(ctx context.Context, master *
 		}
 	}
 
-	// Use isPodReachable rather than isPodReady: SLAVE OF only needs the
-	// admin socket and is itself what starts the dataset load. The
-	// readiness gate below still waits for stable sync before admitting traffic.
+	// SLAVE OF only needs the admin socket and is what starts the dataset load,
+	// so gate on isReachable rather than isPodReady.
 	for _, pod := range pods.Items {
 		if pod.Name == master.Name {
 			continue
 		}
 
-		if !isPodReachable(&pod) {
+		if !isReachable(&pod) {
 			dfi.log.Info("skipping replica configuration; pod not reachable yet", "pod", pod.Name)
 			continue
 		}
@@ -209,10 +203,7 @@ func (dfi *DragonflyInstance) configureReplica(ctx context.Context, pod *corev1.
 }
 
 // reconcileReplicaLabel idempotently re-applies the role=replica label.
-// If Redis already shows the correct master (via INFO replication), we only
-// patch the label — re-issuing SLAVE OF on a healthy replica would provoke
-// a transient "replication cancelled" error. Otherwise falls back to the
-// full configureReplica path.
+// If Redis is already replicating from the right master, only the label is patched.
 func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *corev1.Pod, masterIp string) error {
 	correct, err := dfi.checkReplicaRole(ctx, pod, masterIp)
 	if err == nil && correct {
@@ -346,9 +337,8 @@ func (dfi *DragonflyInstance) checkAndConfigureReplicas(ctx context.Context, mas
 			}
 		}
 
-		// Recover unlabeled pods on isPodReachable rather than isPodReady so
-		// they get a role even while loading a snapshot.
-		if !roleExists(&pod) && isPodReachable(&pod) {
+		// Label unlabeled pods even while loading a snapshot.
+		if !roleExists(&pod) && isReachable(&pod) {
 			if err := dfi.configureReplica(ctx, &pod, masterIp); err != nil {
 				return err
 			}
@@ -525,9 +515,7 @@ func (dfi *DragonflyInstance) detectOldMasters(ctx context.Context, updateRevisi
 }
 
 // replicaOf configures the pod as a replica to the given master instance.
-// SLAVE OF (idempotent on the Dragonfly side) runs first, then the role label
-// is persisted via patchPodMetadata so a transient k8s API conflict cannot
-// leave the pod replicating on Redis without a label on the k8s side.
+// Issues SLAVE OF first, then persists the role label via patchPodMetadata.
 func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, masterIp string) error {
 	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
@@ -582,8 +570,8 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 	return nil
 }
 
-// replicaOfNoOne promotes the given pod to master via SLAVE OF NO ONE, then
-// persists the role=master label with retry-on-conflict semantics.
+
+// replicaOfNoOne configures the pod as a master along while updating other pods to be replicas
 func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Pod) error {
 	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
@@ -957,8 +945,7 @@ func (dfi *DragonflyInstance) deleteMasterRoleLabel(ctx context.Context) error {
 	return nil
 }
 
-// deleteRoleLabel deletes the role label from the given pod. Used during
-// split-brain recovery (ErrIncorrectMasters / ErrNoHealthyMaster).
+// deleteRoleLabel deletes the role label from the given pod.
 func (dfi *DragonflyInstance) deleteRoleLabel(ctx context.Context, pod *corev1.Pod) error {
 	dfi.log.Info("deleting pod role label", "pod", pod.Name, "role", pod.Labels[resources.RoleLabelKey])
 

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -38,7 +38,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -88,6 +90,42 @@ func (dfi *DragonflyInstance) Close() {
 	dfi.redisClients = nil
 }
 
+// patchPodMetadata patches a pod's labels/annotations with retry-on-conflict.
+// Re-GETs the pod inside the retry loop to avoid stale-resourceVersion 409s
+// from concurrent kubelet status writes. NotFound is treated as success so
+// the caller stays idempotent when the pod was deleted between the Redis
+// command and the label update. The mutate callback runs on a fresh pod and
+// must not call the k8s client.
+func (dfi *DragonflyInstance) patchPodMetadata(ctx context.Context, podKey types.NamespacedName, mutate func(*corev1.Pod)) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var pod corev1.Pod
+		if err := dfi.client.Get(ctx, podKey, &pod); err != nil {
+			if apierrors.IsNotFound(err) {
+				dfi.log.Info("pod disappeared before metadata update; skipping", "pod", podKey.String())
+				return nil
+			}
+			return err
+		}
+
+		patch := client.MergeFrom(pod.DeepCopy())
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		mutate(&pod)
+
+		if err := dfi.client.Patch(ctx, &pod, patch); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	})
+}
+
 // configureReplication configures the given pod as a master and other pods as replicas
 func (dfi *DragonflyInstance) configureReplication(ctx context.Context, master *corev1.Pod) error {
 	dfi.log.Info("configuring replication")
@@ -126,32 +164,32 @@ func (dfi *DragonflyInstance) configureReplication(ctx context.Context, master *
 		}
 	}
 
+	// Use isPodReachable rather than isPodReady: SLAVE OF only needs the
+	// admin socket and is itself what starts the dataset load. The
+	// readiness gate below still waits for stable sync before admitting traffic.
 	for _, pod := range pods.Items {
 		if pod.Name == master.Name {
 			continue
 		}
 
-		ready, readyErr := dfi.isPodReady(ctx, &pod)
-		if readyErr != nil {
-			dfi.log.Error(readyErr, "failed to check pod readiness", "pod", pod.Name)
-			return readyErr
+		if !isPodReachable(&pod) {
+			dfi.log.Info("skipping replica configuration; pod not reachable yet", "pod", pod.Name)
+			continue
 		}
 
-		if ready {
-			if err = dfi.configureReplica(ctx, &pod, master.Status.PodIP); err != nil {
-				dfi.log.Error(err, "failed to configure replica", "pod", pod.Name)
-				return err
-			}
+		if err = dfi.configureReplica(ctx, &pod, master.Status.PodIP); err != nil {
+			dfi.log.Error(err, "failed to configure replica", "pod", pod.Name)
+			return err
+		}
 
-			if dfi.df.Spec.EnableReplicationReadinessGate {
-				stable, stableErr := dfi.isReplicaStable(ctx, &pod)
-				if stableErr != nil {
-					stable = false
-				}
-				if patchErr := dfi.patchReplicationReadyCondition(ctx, &pod, stable); patchErr != nil {
-					dfi.log.Error(patchErr, "failed to patch replication ready condition on replica", "pod", pod.Name)
-					return patchErr
-				}
+		if dfi.df.Spec.EnableReplicationReadinessGate {
+			stable, stableErr := dfi.isReplicaStable(ctx, &pod)
+			if stableErr != nil {
+				stable = false
+			}
+			if patchErr := dfi.patchReplicationReadyCondition(ctx, &pod, stable); patchErr != nil {
+				dfi.log.Error(patchErr, "failed to patch replication ready condition on replica", "pod", pod.Name)
+				return patchErr
 			}
 		}
 	}
@@ -168,6 +206,31 @@ func (dfi *DragonflyInstance) configureReplica(ctx context.Context, pod *corev1.
 	}
 
 	return nil
+}
+
+// reconcileReplicaLabel idempotently re-applies the role=replica label.
+// If Redis already shows the correct master (via INFO replication), we only
+// patch the label — re-issuing SLAVE OF on a healthy replica would provoke
+// a transient "replication cancelled" error. Otherwise falls back to the
+// full configureReplica path.
+func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *corev1.Pod, masterIp string) error {
+	correct, err := dfi.checkReplicaRole(ctx, pod, masterIp)
+	if err == nil && correct {
+		dfi.log.Info("Redis already replicating from correct master; only patching missing label", "pod", pod.Name, "master", masterIp)
+		sanitized := sanitizeIp(masterIp)
+		podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+		return dfi.patchPodMetadata(ctx, podKey, func(p *corev1.Pod) {
+			p.Labels[resources.RoleLabelKey] = resources.Replica
+			p.Annotations[resources.MasterIpAnnotationKey] = sanitized
+			if ip := net.ParseIP(sanitized); ip != nil && ip.To4() != nil {
+				p.Labels[resources.MasterIpLabelKey] = sanitized
+			}
+		})
+	}
+	if err != nil {
+		dfi.log.Info("could not inspect Redis replication state; falling back to full configureReplica", "pod", pod.Name, "error", err.Error())
+	}
+	return dfi.configureReplica(ctx, pod, masterIp)
 }
 
 // checkReplicaRole returns true if the given pod is a replica and is connected to the correct master.
@@ -283,17 +346,11 @@ func (dfi *DragonflyInstance) checkAndConfigureReplicas(ctx context.Context, mas
 			}
 		}
 
-		if !roleExists(&pod) {
-			ready, readyErr := dfi.isPodReady(ctx, &pod)
-			if readyErr != nil {
-				dfi.log.Error(readyErr, "failed to check pod readiness", "pod", pod.Name)
-				return readyErr
-			}
-
-			if ready {
-				if err := dfi.configureReplica(ctx, &pod, masterIp); err != nil {
-					return err
-				}
+		// Recover unlabeled pods on isPodReachable rather than isPodReady so
+		// they get a role even while loading a snapshot.
+		if !roleExists(&pod) && isPodReachable(&pod) {
+			if err := dfi.configureReplica(ctx, &pod, masterIp); err != nil {
+				return err
 			}
 		}
 	}
@@ -467,7 +524,10 @@ func (dfi *DragonflyInstance) detectOldMasters(ctx context.Context, updateRevisi
 	return nil
 }
 
-// replicaOf configures the pod as a replica to the given master instance
+// replicaOf configures the pod as a replica to the given master instance.
+// SLAVE OF (idempotent on the Dragonfly side) runs first, then the role label
+// is persisted via patchPodMetadata so a transient k8s API conflict cannot
+// leave the pod replicating on Redis without a label on the k8s side.
 func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, masterIp string) error {
 	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
@@ -498,20 +558,19 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 	}
 
 	dfi.log.Info("Marking pod role as replica", "pod", pod.Name, "masterIp", masterIp)
-	patch := client.MergeFrom(pod.DeepCopy())
-	pod.Labels[resources.RoleLabelKey] = resources.Replica
-	if pod.Annotations == nil {
-		pod.Annotations = make(map[string]string)
-	}
-	pod.Annotations[resources.MasterIpAnnotationKey] = masterIp
+	podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+	if err := dfi.patchPodMetadata(ctx, podKey, func(p *corev1.Pod) {
+		p.Labels[resources.RoleLabelKey] = resources.Replica
+		p.Annotations[resources.MasterIpAnnotationKey] = masterIp
 
-	// for compatibility, to be removed in future version
-	ip := net.ParseIP(masterIp)
-	if ip != nil && ip.To4() != nil {
-		pod.Labels[resources.MasterIpLabelKey] = masterIp
-	}
-
-	if err := dfi.client.Patch(ctx, pod, patch); err != nil {
+		// for compatibility, to be removed in future version
+		if ip := net.ParseIP(masterIp); ip != nil && ip.To4() != nil {
+			p.Labels[resources.MasterIpLabelKey] = masterIp
+		} else {
+			// Clean up any stale v4 label if we're now pointing at a v6 master.
+			delete(p.Labels, resources.MasterIpLabelKey)
+		}
+	}); err != nil {
 		return fmt.Errorf("could not update replica metadata: %w", err)
 	}
 
@@ -523,7 +582,8 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 	return nil
 }
 
-// replicaOfNoOne configures the pod as a master along while updating other pods to be replicas
+// replicaOfNoOne promotes the given pod to master via SLAVE OF NO ONE, then
+// persists the role=master label with retry-on-conflict semantics.
 func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Pod) error {
 	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
@@ -548,17 +608,13 @@ func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Po
 	masterIp := pod.Status.PodIP
 
 	dfi.log.Info("Marking pod role as master", "pod", pod.Name, "masterIp", masterIp)
-	patch := client.MergeFrom(pod.DeepCopy())
-	pod.Labels[resources.RoleLabelKey] = resources.Master
-	delete(pod.Labels, resources.MasterIpLabelKey)
-
-	if pod.Annotations == nil {
-		pod.Annotations = make(map[string]string)
-	}
-	pod.Annotations[resources.MasterIpAnnotationKey] = masterIp
-
-	if err := dfi.client.Patch(ctx, pod, patch); err != nil {
-		return err
+	podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+	if err := dfi.patchPodMetadata(ctx, podKey, func(p *corev1.Pod) {
+		p.Labels[resources.RoleLabelKey] = resources.Master
+		delete(p.Labels, resources.MasterIpLabelKey)
+		p.Annotations[resources.MasterIpAnnotationKey] = masterIp
+	}); err != nil {
+		return fmt.Errorf("could not update master metadata: %w", err)
 	}
 
 	return nil
@@ -901,14 +957,15 @@ func (dfi *DragonflyInstance) deleteMasterRoleLabel(ctx context.Context) error {
 	return nil
 }
 
-// deleteRoleLabel deletes the role label from the given pod
+// deleteRoleLabel deletes the role label from the given pod. Used during
+// split-brain recovery (ErrIncorrectMasters / ErrNoHealthyMaster).
 func (dfi *DragonflyInstance) deleteRoleLabel(ctx context.Context, pod *corev1.Pod) error {
 	dfi.log.Info("deleting pod role label", "pod", pod.Name, "role", pod.Labels[resources.RoleLabelKey])
 
-	patchFrom := client.MergeFrom(pod.DeepCopy())
-	delete(pod.Labels, resources.RoleLabelKey)
-
-	if err := dfi.client.Patch(ctx, pod, patchFrom); err != nil {
+	podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+	if err := dfi.patchPodMetadata(ctx, podKey, func(p *corev1.Pod) {
+		delete(p.Labels, resources.RoleLabelKey)
+	}); err != nil {
 		dfi.log.Error(err, "failed to update the role label", "pod", pod.Name)
 		return err
 	}
@@ -1099,17 +1156,12 @@ func (dfi *DragonflyInstance) replTakeover(ctx context.Context, newMaster *corev
 
 	masterIp := newMaster.Status.PodIP
 
-	patch := client.MergeFrom(newMaster.DeepCopy())
-	newMaster.Labels[resources.RoleLabelKey] = resources.Master
-	delete(newMaster.Labels, resources.MasterIpLabelKey)
-
-	if newMaster.Annotations == nil {
-		newMaster.Annotations = make(map[string]string)
-	}
-	newMaster.Annotations[resources.MasterIpAnnotationKey] = masterIp
-
-	// update the label on the pod
-	if err := dfi.client.Patch(ctx, newMaster, patch); err != nil {
+	podKey := types.NamespacedName{Namespace: newMaster.Namespace, Name: newMaster.Name}
+	if err := dfi.patchPodMetadata(ctx, podKey, func(p *corev1.Pod) {
+		p.Labels[resources.RoleLabelKey] = resources.Master
+		delete(p.Labels, resources.MasterIpLabelKey)
+		p.Annotations[resources.MasterIpAnnotationKey] = masterIp
+	}); err != nil {
 		return fmt.Errorf("failed to update the role label on the pod: %w", err)
 	}
 

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -203,11 +203,11 @@ func (dfi *DragonflyInstance) configureReplica(ctx context.Context, pod *corev1.
 }
 
 // reconcileReplicaLabel idempotently re-applies the role=replica label.
-// If Redis is already replicating from the right master, only the label is patched.
+// If Dragonfly is already replicating from the right master, only the label is patched.
 func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *corev1.Pod, masterIp string) error {
 	correct, err := dfi.checkReplicaRole(ctx, pod, masterIp)
 	if err == nil && correct {
-		dfi.log.Info("Redis already replicating from correct master; only patching missing label", "pod", pod.Name, "master", masterIp)
+		dfi.log.Info("Dragonfly already replicating from correct master; only patching missing label", "pod", pod.Name, "master", masterIp)
 		sanitized := sanitizeIp(masterIp)
 		podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 		return dfi.patchPodMetadata(ctx, podKey, func(p *corev1.Pod) {
@@ -221,7 +221,7 @@ func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *co
 		})
 	}
 	if err != nil {
-		dfi.log.Info("could not inspect Redis replication state; falling back to full configureReplica", "pod", pod.Name, "error", err.Error())
+		dfi.log.Info("could not inspect Dragonfly replication state; falling back to full configureReplica", "pod", pod.Name, "error", err.Error())
 	}
 	return dfi.configureReplica(ctx, pod, masterIp)
 }

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -215,8 +215,8 @@ func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *co
 			p.Annotations[resources.MasterIpAnnotationKey] = sanitized
 			if ip := net.ParseIP(sanitized); ip != nil && ip.To4() != nil {
 				p.Labels[resources.MasterIpLabelKey] = sanitized
-        } else {
-          delete(p.Labels, resources.MasterIpLabelKey)
+			} else {
+				delete(p.Labels, resources.MasterIpLabelKey)
 			}
 		})
 	}

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -205,7 +205,10 @@ func (dfi *DragonflyInstance) configureReplica(ctx context.Context, pod *corev1.
 // reconcileReplicaLabel idempotently re-applies the role=replica label.
 // If Dragonfly is already replicating from the right master, only the label is patched.
 func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *corev1.Pod, masterIp string) error {
-	correct, err := dfi.checkReplicaRole(ctx, pod, masterIp)
+	// For label-only recovery we must trust live INFO replication state, not
+	// pod metadata, to avoid re-labeling pods that still replicate from an old
+	// master due to stale master-ip label/annotation values.
+	correct, err := dfi.checkReplicaLiveMaster(ctx, pod, masterIp)
 	if err == nil && correct {
 		dfi.log.Info("Dragonfly already replicating from correct master; only patching missing label", "pod", pod.Name, "master", masterIp)
 		sanitized := sanitizeIp(masterIp)
@@ -224,6 +227,29 @@ func (dfi *DragonflyInstance) reconcileReplicaLabel(ctx context.Context, pod *co
 		dfi.log.Info("could not inspect Dragonfly replication state; falling back to full configureReplica", "pod", pod.Name, "error", err.Error())
 	}
 	return dfi.configureReplica(ctx, pod, masterIp)
+}
+
+// checkReplicaLiveMaster returns true when INFO replication reports this pod is
+// a replica connected to the expected master IP.
+func (dfi *DragonflyInstance) checkReplicaLiveMaster(ctx context.Context, pod *corev1.Pod, masterIp string) (bool, error) {
+	redisClient := dfi.getRedisClient(pod.Status.PodIP)
+
+	info, err := redisClient.Info(ctx, "replication").Result()
+	if err != nil {
+		return false, err
+	}
+
+	replicationData := parseInfoToMap(info)
+	if role, ok := replicationData["role"]; !ok || role == resources.Master {
+		return false, nil
+	}
+
+	liveMasterIP, ok := replicationData["master_host"]
+	if !ok || liveMasterIP == "" {
+		return false, nil
+	}
+
+	return sanitizeIp(liveMasterIP) == sanitizeIp(masterIp), nil
 }
 
 // checkReplicaRole returns true if the given pod is a replica and is connected to the correct master.

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -158,10 +158,7 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, fmt.Errorf("failed to configure pod as replica: %w", err)
 		}
 
-		r.EventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Replication", "Configured a new replica")
-
-		// Requeue so the next pass sees the freshly-applied label.
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		r.EventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Replication", "Reconciled replica role metadata")
 	}
 
 	if !podReady {

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -146,10 +146,8 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Recover the role label as soon as the admin socket is reachable, before
-	// the !podReady early return below. Otherwise pods loading a snapshot would
-	// never get labeled. reconcileReplicaLabel is idempotent — it only re-issues
-	// SLAVE OF when Redis state is actually wrong.
-	if !roleExists(&pod) && isPodReachable(&pod) {
+	// the !podReady early return below. Otherwise loading pods stay unlabeled.
+	if !roleExists(&pod) && isReachable(&pod) {
 		log.Info("pod has no role label; reconciling as replica (independent of dataset-load state)", "pod", pod.Name)
 
 		if err = dfi.reconcileReplicaLabel(ctx, &pod, master.Status.PodIP); err != nil {
@@ -188,8 +186,7 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			r.EventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Replication", "Checked and configured replication")
 		}
 	} else {
-		// Pod has no role and isn't reachable yet (still booting, no PodIP).
-		// Requeue and the branch above will handle it next time.
+		// No role and not reachable yet; requeue.
 		log.Info("pod has no role label and is not reachable yet; will retry", "pod", pod.Name)
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -145,6 +145,27 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 
+	// Recover the role label as soon as the admin socket is reachable, before
+	// the !podReady early return below. Otherwise pods loading a snapshot would
+	// never get labeled. reconcileReplicaLabel is idempotent — it only re-issues
+	// SLAVE OF when Redis state is actually wrong.
+	if !roleExists(&pod) && isPodReachable(&pod) {
+		log.Info("pod has no role label; reconciling as replica (independent of dataset-load state)", "pod", pod.Name)
+
+		if err = dfi.reconcileReplicaLabel(ctx, &pod, master.Status.PodIP); err != nil {
+			if isReplicationCancelledError(err) {
+				log.Info("replication cancelled (transient), will retry", "error", err)
+				return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("failed to configure pod as replica: %w", err)
+		}
+
+		r.EventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Replication", "Configured a new replica")
+
+		// Requeue so the next pass sees the freshly-applied label.
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
 	if !podReady {
 		log.Info("pod not ready yet, will retry", "pod", pod.Name)
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -167,18 +188,10 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			r.EventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Replication", "Checked and configured replication")
 		}
 	} else {
-		log.Info("pod does not have a role label", "pod", pod.Name)
-
-		if err = dfi.configureReplica(ctx, &pod, master.Status.PodIP); err != nil {
-			// Check for transient replication errors
-			if isReplicationCancelledError(err) {
-				log.Info("replication cancelled (transient), will retry", "error", err)
-				return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
-			}
-			return ctrl.Result{}, fmt.Errorf("failed to configure pod as replica: %w", err)
-		}
-
-		r.EventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Replication", "Configured a new replica")
+		// Pod has no role and isn't reachable yet (still booting, no PodIP).
+		// Requeue and the branch above will handle it next time.
+		log.Info("pod has no role label and is not reachable yet; will retry", "pod", pod.Name)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	if dfi.df.Spec.EnableReplicationReadinessGate {

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -159,6 +159,7 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		r.EventRecorder.Event(dfi.df, corev1.EventTypeNormal, "Replication", "Reconciled replica role metadata")
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 
 	if !podReady {

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -79,6 +79,14 @@ func isHealthy(pod *corev1.Pod) bool {
 	return isRunningAndReady(pod) && !isTerminating(pod)
 }
 
+// isPodReachable returns true if the pod's Dragonfly admin socket is reachable
+// (Running, container Ready, has PodIP, not terminating). Weaker than isPodReady
+// which also requires the dataset to be fully loaded. Used to drive replication
+// commands (SLAVE OF, INFO replication) that only need the admin socket.
+func isPodReachable(pod *corev1.Pod) bool {
+	return isRunningAndReady(pod) && !isTerminating(pod) && pod.Status.PodIP != ""
+}
+
 // isRunningAndReady checks if the pod is running and ready
 func isRunningAndReady(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning && isReady(pod)

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -74,17 +74,9 @@ func roleExists(pod *corev1.Pod) bool {
 	return ok
 }
 
-// isRunningAndReady returns true if the pod is running and ready
-func isHealthy(pod *corev1.Pod) bool {
+// isReachable returns true if the Dragonfly admin socket is reachable.
+func isReachable(pod *corev1.Pod) bool {
 	return isRunningAndReady(pod) && !isTerminating(pod)
-}
-
-// isPodReachable returns true if the pod's Dragonfly admin socket is reachable
-// (Running, container Ready, has PodIP, not terminating). Weaker than isPodReady
-// which also requires the dataset to be fully loaded. Used to drive replication
-// commands (SLAVE OF, INFO replication) that only need the admin socket.
-func isPodReachable(pod *corev1.Pod) bool {
-	return isRunningAndReady(pod) && !isTerminating(pod) && pod.Status.PodIP != ""
 }
 
 // isRunningAndReady checks if the pod is running and ready


### PR DESCRIPTION
Make pod role label updates resilient to API conflicts and dataset-load delays

Three independent but related issues left dragonfly pods stuck without a
role=master/replica label:

1. A lost label Patch (e.g. due to a transient k8s API outage at the
   moment the pod was created) was never recovered. The pod kept
   replicating on the Dragonfly side but had no role label on the k8s
   side, and no later reconcile would re-apply it.

2. The lifecycle reconciler returned early on !podReady — which is true
   for the entire duration of a snapshot load or full sync. Since
   SLAVE OF is what *starts* the load, gating it on "load finished"
   was a self-deadlock: unlabeled pods loading from a snapshot stayed
   unlabeled forever.

3. Label/annotation updates were sent via plain client.Patch against
   the in-memory pod captured at reconcile entry. Concurrent kubelet
   status writes (probes, IPs, conditions) regularly bumped the
   resourceVersion before our patch landed, producing:

       Operation cannot be fulfilled on pods "...": the object has
       been modified; please apply your changes to the latest version
       and try again

Changes:

  * util.go: add isReachable() — Used to gate replication-topology mutations that only need the admin socket.

  * dragonfly_instance.go: add patchPodMetadata() that re-GETs the pod
    inside retry.RetryOnConflict, applies a MergeFrom patch and treats
    IsNotFound as success. All label/annotation writers (replicaOf,
    replicaOfNoOne, replTakeover, deleteRoleLabel) now route through it.

  * dragonfly_instance.go: add reconcileReplicaLabel() — if Redis
    already shows the correct master via INFO replication, only patch
    the missing label; do not re-issue SLAVE OF.

  * dragonfly_instance.go: configureReplication and checkAndConfigureReplicas 
    now iterate pods with isReachable instead of isPodReady.

  * dragonfly_pod_lifecycle_controller.go: move the "no role label →
    reconcile as replica" branch above the !podReady early return,
    gated on iReachable, calling reconcileReplicaLabel. Transient
    "replication cancelled" errors now requeue rather than surfacing
    as reconcile errors.

Verified locally on a Kind cluster across four scenarios: stripped role
label restoration, snapshot-load while unlabeled, rolling update with
concurrent annotation churn, and master-failover. 