### PR TITLE
fix(chart): bump version to v1.6.1 with missing configmap role

### DIFF
--- a/charts/dragonfly-operator/Chart.yaml
+++ b/charts/dragonfly-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.6.0
+version: v1.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.6.0"
+appVersion: "v1.6.1"

--- a/charts/dragonfly-operator/templates/clusterroles.yaml
+++ b/charts/dragonfly-operator/templates/clusterroles.yaml
@@ -10,6 +10,18 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - events
     verbs:
       - create

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: docker.dragonflydb.io/dragonflydb/operator
-    newTag: v1.6.0
+    newTag: v1.6.1

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -7529,7 +7529,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.dragonflydb.io/dragonflydb/operator:v1.6.0
+        image: docker.dragonflydb.io/dragonflydb/operator:v1.6.1
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
The chart is missing the required configmap clusterrole. Tested the fix locally. The PR also bumps the version to v1.6.1.