### PR TITLE
feat(chart): add optional PodDisruptionBudget for the operator pod

### DIFF
--- a/charts/dragonfly-operator/templates/poddisruptionbudget.yaml
+++ b/charts/dragonfly-operator/templates/poddisruptionbudget.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "dragonfly-operator.fullname" . }}
+  labels:
+    {{- include "dragonfly-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    control-plane: controller-manager
+  namespace: {{ include "dragonfly-operator.namespace" . }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dragonfly-operator.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+{{- end }}

--- a/charts/dragonfly-operator/templates/poddisruptionbudget.yaml
+++ b/charts/dragonfly-operator/templates/poddisruptionbudget.yaml
@@ -2,14 +2,14 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "dragonfly-operator.fullname" . }}
+  name: {{ include "dragonfly-operator.fullname" . }}-controller-manager-pod-disruption-budget
   labels:
     {{- include "dragonfly-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
     control-plane: controller-manager
   namespace: {{ include "dragonfly-operator.namespace" . }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- else if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -153,6 +153,21 @@ manager:
 #                values:
 #                  - linux
 
+# -- A [PodDisruptionBudget] for the operator pod, useful when running more
+# than one replica (replicaCount > 1) so voluntary disruptions (e.g. node
+# drains) keep at least one operator pod available.
+## Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  # When set true a PodDisruptionBudget is created for the operator pod
+  enabled: false
+  # minAvailable and maxUnavailable are mutually exclusive; minAvailable takes
+  # precedence when both are set. Each may be an integer or a percentage string.
+  minAvailable: 1
+  maxUnavailable: ""
+  # unhealthyPodEvictionPolicy controls how unhealthy pods are counted (requires
+  # Kubernetes 1.27+). Leave empty to use the cluster default (IfHealthyBudget).
+  unhealthyPodEvictionPolicy: ""
+
 serviceMonitor:
   # When set true then use a ServiceMonitor to configure scraping
   enabled: false


### PR DESCRIPTION
Adds an optional `PodDisruptionBudget` template to the operator Helm chart, disabled by default and toggleable via `podDisruptionBudget.enabled`. Useful when running the operator with `replicaCount > 1` so voluntary disruptions (e.g. node drains) keep at least one operator pod available. The chart already exposes the sibling HA primitives (`replicaCount`, `priorityClassName`, `topologySpreadConstraints`, `affinity`) — this fills the remaining gap.

Supports `minAvailable` (default `1`) / `maxUnavailable` (mutually exclusive, `minAvailable` wins) and the optional `unhealthyPodEvictionPolicy` (k8s 1.27+). The PDB selector matches the deployment's pod selector (`selectorLabels` + `control-plane: controller-manager`).

### Validation (helm v3.18.1)
- `helm lint` — 0 charts failed
- disabled (default): PDB not rendered
- enabled (default `minAvailable: 1`): renders with correct selector
- enabled with `maxUnavailable` + `unhealthyPodEvictionPolicy`: renders correctly
- both `minAvailable` and `maxUnavailable` set: `minAvailable` takes precedence
- `minAvailable: 0` is preserved (not treated as unset)

> The chart `version` is intentionally left unbumped — it is bumped at release time (per maintainer review).

related: #280

Follows up on the closed #281 with a single-purpose, scoped change (PDB only — no ServiceMonitor / kube-rbac-proxy changes).
