### PR TITLE
feat(chart): support for a namespaced scope deployment

### DIFF
--- a/charts/dragonfly-operator/templates/clusterrolebindings.yaml
+++ b/charts/dragonfly-operator/templates/clusterrolebindings.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.watchNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,8 +14,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "dragonfly-operator.serviceAccountName" . }}
     namespace: {{ include "dragonfly-operator.namespace" . }}
+{{- end }}
+{{- if .Values.rbacProxy.enabled }}
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -30,6 +32,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "dragonfly-operator.serviceAccountName" . }}
     namespace: {{ include "dragonfly-operator.namespace" . }}
+{{- end }}
 {{- if .Values.serviceMonitor.enabled }}
 {{- if .Values.rbacProxy.enabled }}
 {{- if .Values.serviceMonitor.rbacProxyMetricsReader.create }}

--- a/charts/dragonfly-operator/templates/clusterroles.yaml
+++ b/charts/dragonfly-operator/templates/clusterroles.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -120,6 +121,8 @@ rules:
       - get
       - patch
       - update
+{{- end }}
+{{- if .Values.rbacProxy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -154,3 +157,4 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+{{- end }}

--- a/charts/dragonfly-operator/templates/deployment.yaml
+++ b/charts/dragonfly-operator/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.watchNamespaces }}
+            - name: WATCH_NAMESPACE
+              value: {{ .Values.watchNamespaces | quote }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.manager.securityContext | nindent 12 }}
           image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion  }}"

--- a/charts/dragonfly-operator/templates/rolebindings.yaml
+++ b/charts/dragonfly-operator/templates/rolebindings.yaml
@@ -14,3 +14,24 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "dragonfly-operator.serviceAccountName" . }}
     namespace: {{ include "dragonfly-operator.namespace" . }}
+{{- if .Values.watchNamespaces }}
+{{- range $ns := splitList "," .Values.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "dragonfly-operator.fullname" $ }}-manager-rolebinding
+  namespace: {{ $ns | trim }}
+  labels:
+    {{- include "dragonfly-operator.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "dragonfly-operator.fullname" $ }}-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dragonfly-operator.serviceAccountName" $ }}
+    namespace: {{ include "dragonfly-operator.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/charts/dragonfly-operator/templates/roles.yaml
+++ b/charts/dragonfly-operator/templates/roles.yaml
@@ -39,4 +39,131 @@ rules:
     verbs:
       - create
       - patch
+{{- if .Values.watchNamespaces }}
+{{- range $ns := splitList "," .Values.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "dragonfly-operator.fullname" $ }}-manager-role
+  namespace: {{ $ns | trim }}
+  labels:
+    {{- include "dragonfly-operator.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dragonflydb.io
+    resources:
+      - dragonflies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dragonflydb.io
+    resources:
+      - dragonflies/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - dragonflydb.io
+    resources:
+      - dragonflies/status
+    verbs:
+      - get
+      - patch
+      - update
+{{- end }}
+{{- end }}
 

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -25,6 +25,13 @@ additionalLabels: {}
 # -- Create aggregated cluster roles for view, edit, and admin
 createAggregateRoles: true
 
+# -- Restrict the operator to specific namespaces (comma-separated, e.g. "ns1,ns2").
+# When set, namespace-scoped Roles are created in each watched namespace instead of a
+# cluster-wide ClusterRole, allowing deployment without ClusterRole permissions.
+# Leave empty to watch all namespaces (default; requires ClusterRole).
+# To fully avoid ClusterRoles, also set rbacProxy.enabled=false and createAggregateRoles=false.
+watchNamespaces: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Summary

There are cases where its not allowed to deploy `ClusterRole` resources. 
This PR adds a `watchNamespaces` value to the Helm chart that enables a namespace-scoped deployment type — no `ClusterRole` required (when rbacProxy is not required).

The operator already supports the `WATCH_NAMESPACE` environment variable to restrict which namespaces it watches. When set, all resources it manages (`Dragonfly`, `StatefulSet`, `Pod`, `Service`, etc.) are namespace-scoped, so a `Role` per watched namespace is sufficient — no `ClusterRole` is needed for the manager.

This PR will also solve the https://github.com/dragonflydb/dragonfly-operator/issues/427.

## Changes

- **`values.yaml`**: new `watchNamespaces` value (empty by default — fully backward compatible)
- **`deployment.yaml`**: injects `WATCH_NAMESPACE` env var when `watchNamespaces` is set
- **`clusterroles.yaml`**: manager `ClusterRole` is skipped when `watchNamespaces` is set; `proxy-role`/`metrics-reader` are now correctly guarded by `rbacProxy.enabled` 
- **`clusterrolebindings.yaml`**: manager `ClusterRoleBinding` skipped when `watchNamespaces` is set; `proxy-clusterrolebinding` now correctly guarded by `rbacProxy.enabled` 
- **`roles.yaml`**: creates a namespace-scoped `Role` in each watched namespace when `watchNamespaces` is set
- **`rolebindings.yaml`**: creates a `RoleBinding` in each watched namespace when `watchNamespaces` is set

## Usage

To deploy without any `ClusterRole`:

```yaml
watchNamespaces: "my-namespace"   # comma-separated for multiple: "ns1,ns2"
rbacProxy.enabled: false
createAggregateRoles: false
```

Default behavior (empty watchNamespaces) is unchanged — the operator watches all namespaces and ClusterRole is used as before.


## Testing
Tested on a local cluster with 4 namespaces: operator, df1, df2, nodf (watchNamespaces: "df1,df2").

Operator deployed at operator
Dragonfly resource created in df1 and df2 — both reconciled correctly, no RBAC errors in logs
Dragonfly resource created in nodf — operator correctly ignored it 
Deleted the master pod in df1 — replica was promoted to master and old master reconfigured as replica
No ClusterRole resources deployed in the cluster