### PR TITLE
chore(controller): configure takeover read timeout 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,6 +94,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	if err := validateReplTakeoverTimeout(replTakeoverTimeout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgrOpts := ctrl.Options{
@@ -258,4 +263,11 @@ func resolveOperatorNamespace(saFile string) string {
 		}
 	}
 	return ""
+}
+
+func validateReplTakeoverTimeout(timeout time.Duration) error {
+	if timeout <= 0 {
+		return fmt.Errorf("repl-takeover-read-timeout must be greater than 0")
+	}
+	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -71,9 +72,11 @@ func main() {
 	var versionFlag bool
 	var watchCurrentNamespace bool
 	var dragonflyImage string
+	var replTakeoverTimeout time.Duration
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&dragonflyImage, "dragonfly-image", "", "The default dragonfly image to use.")
+	flag.DurationVar(&replTakeoverTimeout, "repl-takeover-read-timeout", 10*time.Second, "The Redis client read timeout for REPLTAKEOVER.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -159,6 +162,7 @@ func main() {
 			EventRecorder:         eventRecorder,
 			DefaultDragonflyImage: dragonflyImage,
 			OperatorNamespace:     operatorNamespace,
+			ReplTakeoverTimeout:   replTakeoverTimeout,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Dragonfly")
@@ -172,6 +176,7 @@ func main() {
 			EventRecorder:         eventRecorder,
 			DefaultDragonflyImage: dragonflyImage,
 			OperatorNamespace:     operatorNamespace,
+			ReplTakeoverTimeout:   replTakeoverTimeout,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Health")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestResolveOperatorNamespace(t *testing.T) {
@@ -76,3 +77,38 @@ func TestResolveOperatorNamespace(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestValidateReplTakeoverTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		wantErr bool
+	}{
+		{
+			name:    "positive duration",
+			timeout: time.Second,
+		},
+		{
+			name:    "zero duration",
+			timeout: 0,
+			wantErr: true,
+		},
+		{
+			name:    "negative duration",
+			timeout: -time.Second,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateReplTakeoverTimeout(tt.timeout)
+			if tt.wantErr && err == nil {
+				t.Fatal("validateReplTakeoverTimeout() error = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateReplTakeoverTimeout() error = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/internal/controller/base_controller.go
+++ b/internal/controller/base_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	dfv1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
@@ -33,6 +34,7 @@ type Reconciler struct {
 	EventRecorder         record.EventRecorder
 	DefaultDragonflyImage string
 	OperatorNamespace     string
+	ReplTakeoverTimeout   time.Duration
 }
 
 func (r *Reconciler) getDragonflyInstance(ctx context.Context, namespacedName types.NamespacedName, log logr.Logger) (*DragonflyInstance, error) {
@@ -51,5 +53,6 @@ func (r *Reconciler) getDragonflyInstance(ctx context.Context, namespacedName ty
 		eventRecorder:         r.EventRecorder,
 		defaultDragonflyImage: r.DefaultDragonflyImage,
 		operatorNamespace:     r.OperatorNamespace,
+		replTakeoverTimeout:   r.ReplTakeoverTimeout,
 	}, nil
 }

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -55,6 +55,7 @@ type DragonflyInstance struct {
 	eventRecorder         record.EventRecorder
 	defaultDragonflyImage string
 	operatorNamespace     string
+	replTakeoverTimeout   time.Duration
 	redisClients          map[string]*redis.Client
 }
 
@@ -79,6 +80,24 @@ func (dfi *DragonflyInstance) getRedisClient(podIP string) *redis.Client {
 	})
 	dfi.redisClients[podIP] = c
 	return c
+}
+
+func (dfi *DragonflyInstance) getReplTakeoverRedisClient(podIP string) *redis.Client {
+	readTimeout := dfi.replTakeoverTimeout
+	if readTimeout <= 0 {
+		readTimeout = 10 * time.Second
+	}
+
+	return redis.NewClient(&redis.Options{
+		ClientName:   resources.DragonflyOperatorName,
+		Addr:         net.JoinHostPort(podIP, strconv.Itoa(resources.DragonflyAdminPort)),
+		DialTimeout:  10 * time.Second,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: 10 * time.Second,
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		},
+	})
 }
 
 // Close closes all cached Redis clients.
@@ -1119,7 +1138,8 @@ func (dfi *DragonflyInstance) updatedMaster(ctx context.Context, oldMaster *core
 func (dfi *DragonflyInstance) replTakeover(ctx context.Context, newMaster *corev1.Pod, oldMaster *corev1.Pod) error {
 	dfi.log.Info("running REPLTAKEOVER on replica", "pod", newMaster.Name)
 
-	redisClient := dfi.getRedisClient(newMaster.Status.PodIP)
+	redisClient := dfi.getReplTakeoverRedisClient(newMaster.Status.PodIP)
+	defer redisClient.Close()
 
 	resp, err := redisClient.Do(ctx, "repltakeover", "10000").Result()
 	if err != nil {

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -83,16 +83,11 @@ func (dfi *DragonflyInstance) getRedisClient(podIP string) *redis.Client {
 }
 
 func (dfi *DragonflyInstance) getReplTakeoverRedisClient(podIP string) *redis.Client {
-	readTimeout := dfi.replTakeoverTimeout
-	if readTimeout <= 0 {
-		readTimeout = 10 * time.Second
-	}
-
 	return redis.NewClient(&redis.Options{
 		ClientName:   resources.DragonflyOperatorName,
 		Addr:         net.JoinHostPort(podIP, strconv.Itoa(resources.DragonflyAdminPort)),
 		DialTimeout:  10 * time.Second,
-		ReadTimeout:  readTimeout,
+		ReadTimeout:  dfi.replTakeoverTimeout,
 		WriteTimeout: 10 * time.Second,
 		MaintNotificationsConfig: &maintnotifications.Config{
 			Mode: maintnotifications.ModeDisabled,

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"reflect"
 	"sort"
@@ -87,7 +88,7 @@ func (dfi *DragonflyInstance) getReplTakeoverRedisClient(podIP string) *redis.Cl
 		ClientName:   resources.DragonflyOperatorName,
 		Addr:         net.JoinHostPort(podIP, strconv.Itoa(resources.DragonflyAdminPort)),
 		DialTimeout:  10 * time.Second,
-		ReadTimeout:  dfi.replTakeoverTimeout,
+		ReadTimeout:  dfi.replTakeoverTimeout + 5*time.Second,
 		WriteTimeout: 10 * time.Second,
 		MaintNotificationsConfig: &maintnotifications.Config{
 			Mode: maintnotifications.ModeDisabled,
@@ -1136,7 +1137,7 @@ func (dfi *DragonflyInstance) replTakeover(ctx context.Context, newMaster *corev
 	redisClient := dfi.getReplTakeoverRedisClient(newMaster.Status.PodIP)
 	defer redisClient.Close()
 
-	resp, err := redisClient.Do(ctx, "repltakeover", "10000").Result()
+	resp, err := redisClient.Do(ctx, "repltakeover", strconv.Itoa(dfi.replTakeoverTimeoutSeconds())).Result()
 	if err != nil {
 		return fmt.Errorf("error running REPLTAKEOVER command: %w", err)
 	}
@@ -1176,6 +1177,10 @@ func (dfi *DragonflyInstance) replTakeover(ctx context.Context, newMaster *corev
 	}
 
 	return nil
+}
+
+func (dfi *DragonflyInstance) replTakeoverTimeoutSeconds() int {
+	return int(math.Ceil(dfi.replTakeoverTimeout.Seconds()))
 }
 
 func (dfi *DragonflyInstance) getRedisRole(ctx context.Context, pod *corev1.Pod) (string, error) {

--- a/internal/controller/dragonfly_instance_test.go
+++ b/internal/controller/dragonfly_instance_test.go
@@ -141,6 +141,14 @@ func TestGetReplTakeoverRedisClientUsesConfiguredReadTimeout(t *testing.T) {
 	sharedClient := dfi.getRedisClient("10.0.0.3")
 	defer sharedClient.Close()
 
-	assert.Equal(t, time.Minute, takeoverClient.Options().ReadTimeout)
+	assert.Equal(t, time.Minute+5*time.Second, takeoverClient.Options().ReadTimeout)
 	assert.Equal(t, 10*time.Second, sharedClient.Options().ReadTimeout)
+}
+
+func TestReplTakeoverTimeoutSecondsRoundsUpToDragonflySeconds(t *testing.T) {
+	dfi := &DragonflyInstance{
+		replTakeoverTimeout: 1500 * time.Millisecond,
+	}
+
+	assert.Equal(t, 2, dfi.replTakeoverTimeoutSeconds())
 }

--- a/internal/controller/dragonfly_instance_test.go
+++ b/internal/controller/dragonfly_instance_test.go
@@ -17,12 +17,19 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	dfv1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCopyDesiredPayload_ConfigMapDataUpdated(t *testing.T) {
@@ -93,4 +100,47 @@ func TestResourceSpecsEqual_ConfigMapDataEqual(t *testing.T) {
 	}
 
 	assert.True(t, resourceSpecsEqual(desired, existing))
+}
+
+func TestGetDragonflyInstancePropagatesReplTakeoverReadTimeout(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, dfv1alpha1.AddToScheme(scheme))
+
+	df := &dfv1alpha1.Dragonfly{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dragonfly",
+			Namespace: "default",
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(df).
+		Build()
+	reconciler := Reconciler{
+		Client:              k8sClient,
+		ReplTakeoverTimeout: time.Minute,
+	}
+
+	dfi, err := reconciler.getDragonflyInstance(ctx, types.NamespacedName{Name: df.Name, Namespace: df.Namespace}, logr.Discard())
+	if err != nil {
+		t.Fatalf("getDragonflyInstance() error = %v", err)
+	}
+
+	assert.Equal(t, time.Minute, dfi.replTakeoverTimeout)
+}
+
+func TestGetReplTakeoverRedisClientUsesConfiguredReadTimeout(t *testing.T) {
+	dfi := &DragonflyInstance{
+		replTakeoverTimeout: time.Minute,
+	}
+
+	takeoverClient := dfi.getReplTakeoverRedisClient("10.0.0.2")
+	defer takeoverClient.Close()
+
+	sharedClient := dfi.getRedisClient("10.0.0.3")
+	defer sharedClient.Close()
+
+	assert.Equal(t, time.Minute, takeoverClient.Options().ReadTimeout)
+	assert.Equal(t, 10*time.Second, sharedClient.Options().ReadTimeout)
 }


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

# Description

We have seen issues with the operator-initiated Dragonfly takeover flow. In one deployment with 1 master and 1 replica, `REPLTAKEOVER` can take longer than 40s to complete. The operator Redis client currently times out before the command finishes, which can lead to a retry of the takeover command. That retry can trigger `SIGABRT` in Dragonfly [here](https://github.com/dragonflydb/dragonfly/blob/main/src/server/server_family.cc#L3431).

This PR adds a configurable read timeout only for the `REPLTAKEOVER` path, so operators can set a larger timeout without changing other Redis client operations.

- Adds `--repl-takeover-read-timeout`, configurable via operator container args.
- Uses the configured timeout only for `REPLTAKEOVER`.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 