### PR TITLE
fix: drop removed annotations and labels from live resources on update

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -697,23 +697,14 @@ func (dfi *DragonflyInstance) reconcileResources(ctx context.Context) error {
 		}
 		// Update if specs differ
 		patch := client.MergeFrom(existing.DeepCopyObject().(client.Object))
-		existingAnnotations := existing.GetAnnotations()
-		if existingAnnotations == nil {
-			existingAnnotations = make(map[string]string)
-		}
-		for k, v := range desired.GetAnnotations() {
-			existingAnnotations[k] = v
-		}
-		existing.SetAnnotations(existingAnnotations)
-
-		existingLabels := existing.GetLabels()
-		if existingLabels == nil {
-			existingLabels = make(map[string]string)
-		}
-		for k, v := range desired.GetLabels() {
-			existingLabels[k] = v
-		}
-		existing.SetLabels(existingLabels)
+		// Use the desired object as the source of truth for annotations and
+		// labels. The previous merge copied desired keys on top of the live
+		// object's existing map, so annotations/labels removed from the spec
+		// could never be deleted from the running resource. Setting directly
+		// from desired keeps the live object in sync with the spec, matching
+		// how copyDesiredPayload treats Spec/Data as authoritative.
+		existing.SetAnnotations(desired.GetAnnotations())
+		existing.SetLabels(desired.GetLabels())
 
 		copyDesiredPayload(desired, existing)
 

--- a/internal/controller/dragonfly_instance_test.go
+++ b/internal/controller/dragonfly_instance_test.go
@@ -94,3 +94,40 @@ func TestResourceSpecsEqual_ConfigMapDataEqual(t *testing.T) {
 
 	assert.True(t, resourceSpecsEqual(desired, existing))
 }
+
+// TestReconcileAnnotationsLabelsRemoved verifies that annotations/labels removed
+// from the desired spec are dropped from the live object instead of lingering.
+// The update path sets existing annotations/labels directly from desired, so a
+// key present only on the live object must be gone after sync.
+func TestReconcileAnnotationsLabelsRemoved(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "df-liveness",
+			Namespace:   "default",
+			Annotations: map[string]string{"old.io/keep": "1", "removed.io/stale": "x"},
+			Labels:      map[string]string{"app": "df", "removed.io/stale": "y"},
+		},
+		Data: map[string]string{"liveness-check.sh": "echo old"},
+	}
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "df-liveness",
+			Namespace:   "default",
+			Annotations: map[string]string{"old.io/keep": "1"},
+			Labels:      map[string]string{"app": "df"},
+		},
+		Data: map[string]string{"liveness-check.sh": "echo new"},
+	}
+
+	// Mirror the update path in reconcileResources: annotations/labels come
+	// straight from desired, then payload is copied from desired.
+	existing.SetAnnotations(desired.GetAnnotations())
+	existing.SetLabels(desired.GetLabels())
+	copyDesiredPayload(desired, existing)
+
+	assert.NotContains(t, existing.GetAnnotations(), "removed.io/stale",
+		"annotations removed from the spec must not persist on the live object")
+	assert.NotContains(t, existing.GetLabels(), "removed.io/stale",
+		"labels removed from the spec must not persist on the live object")
+	assert.Equal(t, "echo new", existing.Data["liveness-check.sh"])
+}


### PR DESCRIPTION
reconcileResources merged desired annotations and labels on top of the live object's existing map when preparing an update. A key present on the running resource but removed from the Dragonfly spec kept lingering forever, because the merge only adds or overwrites and never deletes stale keys. The resourceSpecsEqual skip check then never went true for the removal, so the stale key could not be cleaned up. Set the live object's annotations and labels directly from the desired spec, matching how copyDesiredPayload already treats Spec and Data as authoritative. Added TestReconcileAnnotationsLabelsRemoved to assert removed keys are dropped.