### PR TITLE
feat: add spec.additionalVolumeMounts for the main container

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -88,6 +88,13 @@ type DragonflySpec struct {
 	// +kubebuilder:validation:Optional
 	AdditionalVolumes []corev1.Volume `json:"additionalVolumes,omitempty"`
 
+	// (Optional) Additional volume mounts to add to the Dragonfly main container.
+	// Pair with additionalVolumes to mount an extra volume — e.g. back the snapshot
+	// dir with an emptyDir. Replace mount on name collision.
+	// +optional
+	// +kubebuilder:validation:Optional
+	AdditionalVolumeMounts []corev1.VolumeMount `json:"additionalVolumeMounts,omitempty"`
+
 	// (Optional) Dragonfly container resource limits. Any container limits
 	// can be specified.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -168,6 +168,13 @@ func (in *DragonflySpec) DeepCopyInto(out *DragonflySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AdditionalVolumeMounts != nil {
+		in, out := &in.AdditionalVolumeMounts, &out.AdditionalVolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -1598,6 +1598,73 @@ spec:
                   - name
                   type: object
                 type: array
+              additionalVolumeMounts:
+                description: |-
+                  (Optional) Additional volume mounts to add to the Dragonfly main container.
+                  Pair with additionalVolumes to mount an extra volume — e.g. back the snapshot
+                  dir with an emptyDir. Replace mount on name collision.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
+                        When not set, MountPropagationNone is used.
+                        This field is beta in 1.10.
+                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                        (which defaults to None).
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
+                      type: boolean
+                    recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
+
+                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                        recursively read-only, if it is supported by the container runtime.  If this
+                        field is set to Enabled, the mount is made recursively read-only if it is
+                        supported by the container runtime, otherwise the pod will not be started and
+                        an error will be generated to indicate the reason.
+
+                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                        None (or be unspecified, which defaults to None).
+
+                        If this field is not specified, it is treated as an equivalent of Disabled.
+                      type: string
+                    subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: |-
+                        Expanded path within the volume from which the container's volume should be mounted.
+                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                        Defaults to "" (volume's root).
+                        SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
               additionalVolumes:
                 description: (Optional) Additional volumes to add to dragonflycluster.
                   Replace volume on name collision.

--- a/config/samples/v1alpha1_dragonfly_emptydir_snapshot.yaml
+++ b/config/samples/v1alpha1_dragonfly_emptydir_snapshot.yaml
@@ -1,0 +1,24 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: dragonfly-emptydir-snapshot
+    app.kubernetes.io/part-of: dragonfly-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: dragonfly-operator
+  name: dragonfly-emptydir-snapshot
+spec:
+  replicas: 2
+  # Back the snapshot dir with an emptyDir using additionalVolumes +
+  # additionalVolumeMounts. Survives in-place container restarts (e.g. a kubelet
+  # upgrade) without pinning the pod to a node like a local-path PVC does.
+  snapshot:
+    dir: /dragonfly/snapshots
+    cron: "0 */6 * * *"  # Snapshot every 6 hours
+  additionalVolumes:
+    - name: snapshots
+      emptyDir: {}
+  additionalVolumeMounts:
+    - name: snapshots
+      mountPath: /dragonfly/snapshots

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -559,6 +559,13 @@ func GenerateDragonflyResources(df *resourcesv1.Dragonfly, defaultDragonflyImage
 		}
 	}
 
+	// Mount extra volume mounts into the main container before additionalContainers
+	// are merged in: that merge prepends additional containers and would shift the
+	// main container off index 0.
+	statefulset.Spec.Template.Spec.Containers[0].VolumeMounts = mergeNamedSlices(
+		statefulset.Spec.Template.Spec.Containers[0].VolumeMounts, df.Spec.AdditionalVolumeMounts,
+		func(m corev1.VolumeMount) string { return m.Name })
+
 	statefulset.Spec.Template.Spec.Containers = mergeNamedSlices(
 		statefulset.Spec.Template.Spec.Containers, df.Spec.AdditionalContainers,
 		func(c corev1.Container) string { return c.Name })

--- a/internal/resources/resources_volumemounts_test.go
+++ b/internal/resources/resources_volumemounts_test.go
@@ -1,0 +1,106 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// additionalVolumeMounts must be added to the Dragonfly main container. Combined
+// with additionalVolumes this lets a user back the snapshot dir with an emptyDir.
+func TestAdditionalVolumeMounts(t *testing.T) {
+	df := newTestDragonfly(2)
+	df.Spec.AdditionalVolumes = []corev1.Volume{
+		{Name: "snapshots", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}
+	df.Spec.AdditionalVolumeMounts = []corev1.VolumeMount{
+		{Name: "snapshots", MountPath: "/dragonfly/snapshots"},
+	}
+
+	objs, err := GenerateDragonflyResources(df, "", "dragonfly-operator-system")
+	require.NoError(t, err)
+	sts := findStatefulSet(objs)
+	require.NotNil(t, sts)
+
+	var vol *corev1.Volume
+	for i := range sts.Spec.Template.Spec.Volumes {
+		if sts.Spec.Template.Spec.Volumes[i].Name == "snapshots" {
+			vol = &sts.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	require.NotNil(t, vol, "additionalVolumes must add the volume to the pod")
+	require.NotNil(t, vol.EmptyDir)
+
+	var mount *corev1.VolumeMount
+	for i := range sts.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if sts.Spec.Template.Spec.Containers[0].VolumeMounts[i].Name == "snapshots" {
+			mount = &sts.Spec.Template.Spec.Containers[0].VolumeMounts[i]
+		}
+	}
+	require.NotNil(t, mount, "additionalVolumeMounts must be added to the main container")
+	assert.Equal(t, "/dragonfly/snapshots", mount.MountPath)
+}
+
+// additionalVolumeMounts must land on the Dragonfly main container only, never on
+// sidecars added via additionalContainers.
+func TestAdditionalVolumeMountsNotAddedToAdditionalContainers(t *testing.T) {
+	df := newTestDragonfly(2)
+	df.Spec.AdditionalContainers = []corev1.Container{
+		{Name: "sidecar", Image: "busybox"},
+	}
+	df.Spec.AdditionalVolumeMounts = []corev1.VolumeMount{
+		{Name: "snapshots", MountPath: "/dragonfly/snapshots"},
+	}
+
+	objs, err := GenerateDragonflyResources(df, "", "dragonfly-operator-system")
+	require.NoError(t, err)
+	sts := findStatefulSet(objs)
+	require.NotNil(t, sts)
+
+	hasMount := func(c corev1.Container) bool {
+		for _, m := range c.VolumeMounts {
+			if m.Name == "snapshots" {
+				return true
+			}
+		}
+		return false
+	}
+
+	var main, sidecar *corev1.Container
+	for i := range sts.Spec.Template.Spec.Containers {
+		switch sts.Spec.Template.Spec.Containers[i].Name {
+		case DragonflyContainerName:
+			main = &sts.Spec.Template.Spec.Containers[i]
+		case "sidecar":
+			sidecar = &sts.Spec.Template.Spec.Containers[i]
+		}
+	}
+	require.NotNil(t, main, "main dragonfly container must be present")
+	require.NotNil(t, sidecar, "sidecar container must be present")
+
+	assert.True(t, hasMount(*main), "additionalVolumeMounts must be on the main container")
+	assert.False(t, hasMount(*sidecar), "additionalVolumeMounts must not be on additional containers")
+}
+
+// on name collision, the user-supplied mount replaces the operator's default mount.
+func TestAdditionalVolumeMountsReplaceOnCollision(t *testing.T) {
+	df := newTestDragonfly(2)
+	df.Spec.AdditionalVolumeMounts = []corev1.VolumeMount{
+		{Name: "custom", MountPath: "/custom"},
+	}
+
+	objs, err := GenerateDragonflyResources(df, "", "dragonfly-operator-system")
+	require.NoError(t, err)
+	sts := findStatefulSet(objs)
+	require.NotNil(t, sts)
+
+	count := 0
+	for _, m := range sts.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if m.Name == "custom" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "expected exactly one mount named custom")
+}


### PR DESCRIPTION
## What

Adds `spec.additionalVolumeMounts` — extra volume mounts for the Dragonfly **main container**. It is the counterpart to the existing `spec.additionalVolumes`, which adds volumes to the pod but does not mount them anywhere.

## Why

`additionalVolumes` on its own is half a feature: you can add a volume to the pod but cannot mount it into the Dragonfly container. Pairing the two lets users compose several patterns **without any snapshot-specific API**, e.g.:

- **Back the snapshot dir (`spec.snapshot.dir`) with an `emptyDir`.** Dragonfly saves on SIGTERM and reloads on start, so an emptyDir snapshot survives in-place container restarts (e.g. a kubelet minor upgrade that changes the container hash) **without pinning the pod to a node** the way a local-path PVC does.
- **Read-only warm-up cache** — mount a golden snapshot read-only; every start loads it, runtime writes never touch the on-disk copy.
- **Combine** an init-seeded `emptyDir` for warm-up + crash protection.

Usage examples (all validated end-to-end on a cluster): https://gist.github.com/IgorOhrimenko/d679e593637e0fbe62525f165fd17d78

## Implementation

- Merged into the main container by name (a user mount replaces the operator's default on collision), mirroring how `additionalVolumes` / `additionalContainers` already merge.
- Applied **before** the `additionalContainers` merge, since that merge prepends additional containers and would otherwise shift the main container off index 0.

## Testing

- Unit tests in `internal/resources`, including one asserting mounts land on the main container only and never on `additionalContainers`.
- Added a `config/samples` example (`v1alpha1_dragonfly_emptydir_snapshot.yaml`).
- Verified on a live cluster: emptyDir survives simultaneous both-pod container restarts (data preserved); a read-only seed stays immutable across restarts; the init-seed + emptyDir combo warms from a baseline and keeps runtime growth across in-place restarts.

Backward compatible — the field is optional and existing specs are unaffected.

> Note: I regenerated `config/crd/bases` (`make manifests`) but intentionally left the `manifests/` bundle untouched — it is already out of sync with `config/` on `main` (missing some recent upstream API-type updates), so regenerating it here would add unrelated churn. Happy to include a bundle regeneration if you prefer.
