### PR TITLE
Improve error message in reconcileResources

### DIFF
--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -619,7 +619,7 @@ func (dfi *DragonflyInstance) hasMasterRole(ctx context.Context, redisClient *re
 func (dfi *DragonflyInstance) reconcileResources(ctx context.Context) error {
 	dfResources, err := resources.GenerateDragonflyResources(dfi.df, dfi.defaultDragonflyImage, dfi.operatorNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to generate dragonfly resources")
+		return fmt.Errorf("failed to generate dragonfly resources: %w", err)
 	}
 	for _, desired := range dfResources {
 		dfi.log.Info("reconciling dragonfly resource", "kind", getGVK(desired, dfi.scheme).Kind, "namespace", desired.GetNamespace(), "Name", desired.GetName())


### PR DESCRIPTION
Include the original error in the error message for better debugging.

I am seeing this a lot and have issues with troubleshooting:

```log
manager 2026-08-06T08:44:10Z    INFO    setup    Operator namespace: dragonfly-operator-system
manager 2026-08-06T08:44:10Z    INFO    setup    starting manager
manager 2026-08-06T08:44:10Z    INFO    setup    Watch all namespaces.
manager 2026-08-06T08:44:10Z    INFO    controller-runtime.metrics    Starting metrics server
manager 2026-08-06T08:44:10Z    INFO    starting server    {"name": "health probe", "addr": "[::]:8081"}
manager 2026-08-06T08:44:10Z    INFO    controller-runtime.metrics    Serving metrics server    {"bindAddress": "127.0.0.1:8080", "secure": false}
manager I0806 08:44:10.577207       1 leaderelection.go:257] attempting to acquire leader lease dragonfly-operator-system/31079dea.dragonflydb.io...
manager I0806 08:44:26.877210       1 leaderelection.go:271] successfully acquired lease dragonfly-operator-system/31079dea.dragonflydb.io
manager 2026-08-06T08:44:26Z    DEBUG    events    dragonfly-dragonfly-operator-576476c699-4mspt_b82c8fca-5308-4f33-89a9-1d2a333f7123 became leader    {"type": "Normal", "object": {"kind":"Lease","namespace":"dragonfly-operator-system","name":"31079dea.dragonflydb.io","uid":"2f8ea9b3-10a0-4660-af2c-c56857143fc0","apiVersion":"coordination.k8s.io/v1","resourceVersion":"61980"}, "reason": "LeaderElection"}
manager 2026-08-06T08:44:26Z    INFO    Starting EventSource    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "source": "kind source: *v1.NetworkPolicy"}
manager 2026-08-06T08:44:26Z    INFO    Starting EventSource    {"controller": "DragonflyPodLifecycle", "controllerGroup": "", "controllerKind": "Pod", "source": "kind source: *v1.Pod"}
manager 2026-08-06T08:44:26Z    INFO    Starting EventSource    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "source": "kind source: *v1.ConfigMap"}
manager 2026-08-06T08:44:26Z    INFO    Starting EventSource    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "source": "kind source: *v1alpha1.Dragonfly"}
manager 2026-08-06T08:44:26Z    INFO    Starting EventSource    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "source": "kind source: *v1.StatefulSet"}
manager 2026-08-06T08:44:26Z    INFO    Starting EventSource    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "source": "kind source: *v1.Service"}
manager 2026-08-06T08:44:27Z    INFO    Starting Controller    {"controller": "DragonflyPodLifecycle", "controllerGroup": "", "controllerKind": "Pod"}
manager 2026-08-06T08:44:27Z    INFO    Starting workers    {"controller": "DragonflyPodLifecycle", "controllerGroup": "", "controllerKind": "Pod", "worker count": 1}
manager 2026-08-06T08:44:27Z    INFO    Starting Controller    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly"}
manager 2026-08-06T08:44:27Z    INFO    Starting workers    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "worker count": 1}
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "c976a4ae-3377-4245-b4f3-cc2ce09b3da5"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "c976a4ae-3377-4245-b4f3-cc2ce09b3da5", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "6a195344-75e3-45b2-8d5e-c040beea8738"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "6a195344-75e3-45b2-8d5e-c040beea8738", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "79664fcd-eb73-4a8f-b3bc-71ef77390464"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "79664fcd-eb73-4a8f-b3bc-71ef77390464", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "04145ff5-b143-450e-85ab-3fd72b40a7d1"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "04145ff5-b143-450e-85ab-3fd72b40a7d1", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "2e58ef33-d38d-490a-892c-da04340747f8"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "2e58ef33-d38d-490a-892c-da04340747f8", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "737d4cd4-60c7-4e1c-8b38-ce5e297e7ce9"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "737d4cd4-60c7-4e1c-8b38-ce5e297e7ce9", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "92ccd222-ec85-4956-9337-dca3019d408b"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "92ccd222-ec85-4956-9337-dca3019d408b", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:27Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "0d67c91d-9ccb-451b-89c2-c0721e779620"}
manager 2026-08-06T08:44:27Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "0d67c91d-9ccb-451b-89c2-c0721e779620", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:28Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "7e0d2bb5-cf4f-4660-977e-671381e8c6ea"}
manager 2026-08-06T08:44:28Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "7e0d2bb5-cf4f-4660-977e-671381e8c6ea", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:29Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "0c44edfe-01dc-4d98-9d66-01d35f8435a0"}
manager 2026-08-06T08:44:29Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "0c44edfe-01dc-4d98-9d66-01d35f8435a0", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:32Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "760fadff-ebfe-4002-9944-20029e53983b"}
manager 2026-08-06T08:44:32Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "760fadff-ebfe-4002-9944-20029e53983b", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:37Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "be7a61f0-66bd-45f1-8abf-9b6dc30ca6c6"}
manager 2026-08-06T08:44:37Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "be7a61f0-66bd-45f1-8abf-9b6dc30ca6c6", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:44:47Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "0a9e80e8-c16c-4150-ade1-be950707980a"}
manager 2026-08-06T08:44:47Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "0a9e80e8-c16c-4150-ade1-be950707980a", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
manager 2026-08-06T08:45:07Z    INFO    reconciling dragonfly instance    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "493a6318-3602-4727-adb4-42d834ca44d7"}
manager 2026-08-06T08:45:07Z    ERROR    Reconciler error    {"controller": "Dragonfly", "controllerGroup": "dragonflydb.io", "controllerKind": "Dragonfly", "Dragonfly": {"name":"harbor-dragonfly","namespace":"harbor-system"}, "namespace": "harbor-system", "name": "harbor-dragonfly", "reconcileID": "493a6318-3602-4727-adb4-42d834ca44d7", "error": "failed to reconcile dragonfly resources: failed to generate dragonfly resources"}
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->