### PR TITLE
feat(controller): add spec.flushOnFailover to flush a promoted master

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -189,6 +189,14 @@ type DragonflySpec struct {
 	// +kubebuilder:validation:Optional
 	EnableReplicationReadinessGate bool `json:"enableReplicationReadinessGate,omitempty"`
 
+	// (Optional) When enabled, an instance that is promoted to master during an unplanned
+	// failover is flushed before it starts serving traffic. Use this for cache workloads that
+	// must not serve data which is stale relative to the master that was lost. Planned rolling
+	// updates promote through a coordinated takeover and are not affected.
+	// +optional
+	// +kubebuilder:validation:Optional
+	FlushOnFailover bool `json:"flushOnFailover,omitempty"`
+
 	// (Optional) Whether to create a NetworkPolicy for this Dragonfly instance.
 	// The NetworkPolicy restricts admin port access to operator and peer pods only.
 	// Defaults to true.

--- a/charts/dragonfly-operator/templates/crds.yaml
+++ b/charts/dragonfly-operator/templates/crds.yaml
@@ -4640,6 +4640,13 @@ spec:
                   - name
                   type: object
                 type: array
+              flushOnFailover:
+                description: |-
+                  (Optional) When enabled, an instance that is promoted to master during an unplanned
+                  failover is flushed before it starts serving traffic. Use this for cache workloads that
+                  must not serve data which is stale relative to the master that was lost. Planned rolling
+                  updates promote through a coordinated takeover and are not affected.
+                type: boolean
               image:
                 description: Image is the Dragonfly image to use
                 type: string

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -4880,6 +4880,13 @@ spec:
                   - name
                   type: object
                 type: array
+              flushOnFailover:
+                description: |-
+                  (Optional) When enabled, an instance that is promoted to master during an unplanned
+                  failover is flushed before it starts serving traffic. Use this for cache workloads that
+                  must not serve data which is stale relative to the master that was lost. Planned rolling
+                  updates promote through a coordinated takeover and are not affected.
+                type: boolean
               image:
                 description: Image is the Dragonfly image to use
                 type: string

--- a/e2e/dragonfly_flush_on_failover_test.go
+++ b/e2e/dragonfly_flush_on_failover_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2023 DragonflyDB authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	dfv1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
+	"github.com/dragonflydb/dragonfly-operator/internal/controller"
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("DF Flush On Failover", Ordered, FlakeAttempts(3), func() {
+	ctx := context.Background()
+	name := "flush-on-failover-test"
+	namespace := "default"
+	replicas := 2
+
+	disabled := false
+	df := dfv1alpha1.Dragonfly{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: dfv1alpha1.DragonflySpec{
+			Replicas:             int32(replicas),
+			NetworkPolicyEnabled: &disabled,
+			FlushOnFailover:      true,
+		},
+	}
+
+	Context("A promoted master is flushed", func() {
+		It("Instance is created and ready", func() {
+			Expect(k8sClient.Create(ctx, &df)).To(BeNil())
+
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 3*time.Minute)).To(BeNil())
+			Expect(waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)).To(BeNil())
+			Expect(waitForMasterPod(ctx, k8sClient, name, namespace, 2*time.Minute)).To(BeNil())
+		})
+
+		It("Data replicated before the failover is dropped on the promoted master", func() {
+			// Write to the current master.
+			stopChan := make(chan struct{}, 1)
+			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, "", 6397)
+			Expect(err).To(BeNil())
+			Expect(rc.Set(ctx, "foo", "bar", 0).Err()).To(BeNil())
+			close(stopChan)
+			rc.Close()
+
+			master, replica, err := getMasterReplica(ctx, namespace, name)
+			Expect(err).To(BeNil())
+
+			// The replica has to actually hold the data before the master is killed, otherwise an
+			// empty dataset after the promotion would prove nothing.
+			replicaPF, err := setupPortForwardWithCleanup(ctx, clientset, cfg, replica, resources.DragonflyPort, 30*time.Second)
+			Expect(err).To(BeNil())
+			replicaClient := redis.NewClient(&redis.Options{
+				Addr: fmt.Sprintf("localhost:%d", replicaPF.LocalPort),
+			})
+			Eventually(func() (string, error) {
+				return replicaClient.Get(ctx, "foo").Result()
+			}, 1*time.Minute, 2*time.Second).Should(Equal("bar"))
+			replicaClient.Close()
+			replicaPF.Cleanup()
+
+			// Kill the master: the operator promotes the replica with SLAVE OF NO ONE and, with
+			// flushOnFailover enabled, flushes it before labelling it as the new master.
+			Expect(k8sClient.Delete(ctx, master)).To(BeNil())
+
+			Expect(waitForMasterPod(ctx, k8sClient, name, namespace, 2*time.Minute)).To(BeNil())
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)).To(BeNil())
+
+			// The pod that was a replica is the one that got promoted.
+			Eventually(func() (string, error) {
+				newMaster, _, err := getMasterReplica(ctx, namespace, name)
+				if err != nil {
+					return "", err
+				}
+				return newMaster.Name, nil
+			}, 2*time.Minute, 5*time.Second).Should(Equal(replica.Name))
+
+			// And it serves an empty dataset.
+			stopChan = make(chan struct{}, 1)
+			rc, err = checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, "", 6398)
+			Expect(err).To(BeNil())
+			defer close(stopChan)
+			defer rc.Close()
+
+			Expect(rc.DBSize(ctx).Result()).To(BeEquivalentTo(0))
+		})
+
+		It("Cleanup", func() {
+			var df dfv1alpha1.Dragonfly
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, &df)).To(BeNil())
+
+			Expect(k8sClient.Delete(ctx, &df)).To(BeNil())
+		})
+	})
+})

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -528,6 +528,18 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Pod) error {
 	redisClient := dfi.getRedisClient(pod.Status.PodIP)
 
+	// Only a pod that is currently a replica is being promoted. This function also runs during
+	// initial master election, where the pod is already a master and its dataset (for example one
+	// restored from a snapshot) must be kept.
+	promoted := false
+	if dfi.df.Spec.FlushOnFailover {
+		hasMaster, err := dfi.hasMasterRole(ctx, redisClient)
+		if err != nil {
+			return fmt.Errorf("failed to get the role of pod %s: %w", pod.Name, err)
+		}
+		promoted = !hasMaster
+	}
+
 	dfi.log.Info("running SLAVE OF NO ONE command", "pod", pod.Name, "addr", redisClient.Options().Addr)
 	resp, err := redisClient.SlaveOf(ctx, "NO", "ONE").Result()
 	if err != nil {
@@ -536,6 +548,15 @@ func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Po
 
 	if resp != "OK" {
 		return fmt.Errorf("response of `SLAVE OF NO ONE` on master is not OK: %s", resp)
+	}
+
+	// Flushed before the role label below is patched: the master Service selects on that label, so
+	// the promoted pod is not an endpoint of it yet and no client can read the stale dataset.
+	if promoted {
+		dfi.log.Info("flushing the promoted master", "pod", pod.Name)
+		if _, err := redisClient.FlushAll(ctx).Result(); err != nil {
+			return fmt.Errorf("failed to flush the promoted master %s: %w", pod.Name, err)
+		}
 	}
 
 	if dfi.df.Spec.Snapshot != nil && dfi.df.Spec.Snapshot.EnableOnMasterOnly {

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -4633,6 +4633,13 @@ spec:
                   - name
                   type: object
                 type: array
+              flushOnFailover:
+                description: |-
+                  (Optional) When enabled, an instance that is promoted to master during an unplanned
+                  failover is flushed before it starts serving traffic. Use this for cache workloads that
+                  must not serve data which is stale relative to the master that was lost. Planned rolling
+                  updates promote through a coordinated takeover and are not affected.
+                type: boolean
               image:
                 description: Image is the Dragonfly image to use
                 type: string

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -4646,6 +4646,13 @@ spec:
                   - name
                   type: object
                 type: array
+              flushOnFailover:
+                description: |-
+                  (Optional) When enabled, an instance that is promoted to master during an unplanned
+                  failover is flushed before it starts serving traffic. Use this for cache workloads that
+                  must not serve data which is stale relative to the master that was lost. Planned rolling
+                  updates promote through a coordinated takeover and are not affected.
+                type: boolean
               image:
                 description: Image is the Dragonfly image to use
                 type: string


### PR DESCRIPTION
# PR description

## Summary

Adds an opt-in `spec.flushOnFailover` field. When it is set, a replica promoted during an unplanned
failover is flushed right after `SLAVE OF NO ONE` and before its `role: master` label is patched.
This is for cache workloads that must not serve data which is stale relative to the master that was
lost: the promoted pod can be behind the dead master, and today there is no way to have the new
master start empty.

The placement between those two calls is the point of doing this in the operator. The master
Service selects on `RoleLabelKey: Master` (`internal/resources/resources.go`), so while the flush
runs the promoted pod is not an endpoint of it yet and no client can read the stale dataset through
the Service.

This follows the discussion in dragonflydb/dragonfly#8051, where the conclusion was that the policy
belongs here rather than in a Dragonfly server flag.

## Changes

* New optional field `DragonflySpec.FlushOnFailover`, default `false`.
* `replicaOfNoOne()` issues `FLUSHALL` after a successful `SLAVE OF NO ONE`, guarded by a check that
  the pod really was a replica before the call.
* Regenerated CRDs: `config/crd/bases`, `manifests/`, `charts/`.

## Behavior

* Default `false` — no change for existing deployments.
* The role check matters: `replicaOfNoOne()` also runs during initial master election, where the pod
  is already a master and its dataset — for example one restored from a snapshot after a full
  restart — must be preserved. Only a replica -> master transition flushes.
* Rolling updates are unaffected. They promote through `updatedMaster()` -> `replTakeover()`, a
  coordinated takeover that loses no data, so flushing there would mean a cold cache and a backend
  load spike on every upgrade.
* A failing `FLUSHALL` returns before the role label is patched, so the pod is never advertised as
  master with a stale dataset; the reconciler retries.

## Testing

Manually, on a 3-replica instance with the field enabled: delete the master pod, then confirm the
promoted pod logs `flushing the promoted master` and reports `dbsize` 0, and that the remaining
replicas come back empty after they re-sync.

