### PR TITLE
fix(operator): avoid nil dereference in getCurrentNamespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -213,13 +214,28 @@ func getWatchNamespaceFromEnvVariable() string {
 	return ns
 }
 
+const defaultNamespace = "default"
+
 func getCurrentNamespace() string {
-	clientCfg, _ := clientcmd.NewDefaultClientConfigLoadingRules().Load()
-	ns := clientCfg.Contexts[clientCfg.CurrentContext].Namespace
-	if ns == "" {
-		ns = "default"
+	clientCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	if err != nil {
+		setupLog.Error(err, "failed to load kubeconfig, falling back to the default namespace")
+		return defaultNamespace
 	}
-	return ns
+	return resolveCurrentNamespace(clientCfg)
+}
+
+func resolveCurrentNamespace(clientCfg *clientcmdapi.Config) string {
+	if clientCfg == nil {
+		return defaultNamespace
+	}
+
+	kubeContext, ok := clientCfg.Contexts[clientCfg.CurrentContext]
+	if !ok || kubeContext == nil || kubeContext.Namespace == "" {
+		return defaultNamespace
+	}
+
+	return kubeContext.Namespace
 }
 
 func addNamespacesToOpts(namespaces string, ops *ctrl.Options) error {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestResolveOperatorNamespace(t *testing.T) {
@@ -76,3 +78,65 @@ func TestResolveOperatorNamespace(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestResolveCurrentNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		clientCfg *clientcmdapi.Config
+		want      string
+	}{
+		{
+			name:      "nil config",
+			clientCfg: nil,
+			want:      "default",
+		},
+		{
+			name:      "empty config",
+			clientCfg: clientcmdapi.NewConfig(),
+			want:      "default",
+		},
+		{
+			name: "unknown current context",
+			clientCfg: &clientcmdapi.Config{
+				CurrentContext: "missing",
+				Contexts: map[string]*clientcmdapi.Context{
+					"other": {Namespace: "other-ns"},
+				},
+			},
+			want: "default",
+		},
+		{
+			name: "nil context",
+			clientCfg: &clientcmdapi.Config{
+				CurrentContext: "broken",
+				Contexts:       map[string]*clientcmdapi.Context{"broken": nil},
+			},
+			want: "default",
+		},
+		{
+			name: "context without namespace",
+			clientCfg: &clientcmdapi.Config{
+				CurrentContext: "ctx",
+				Contexts:       map[string]*clientcmdapi.Context{"ctx": {}},
+			},
+			want: "default",
+		},
+		{
+			name: "context with namespace",
+			clientCfg: &clientcmdapi.Config{
+				CurrentContext: "ctx",
+				Contexts:       map[string]*clientcmdapi.Context{"ctx": {Namespace: "my-ns"}},
+			},
+			want: "my-ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveCurrentNamespace(tt.clientCfg)
+			if got != tt.want {
+				t.Errorf("resolveCurrentNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In-cluster there is no kubeconfig, so Load() returns an empty config, leading to a nil dereference. Only reachable with --watch-current-namespace

Fixes #538