### PR TITLE
feat(operator): auto-create Dragonfly credentials secret

### DIFF
--- a/api/v1alpha1/dragonfly_types.go
+++ b/api/v1alpha1/dragonfly_types.go
@@ -305,6 +305,14 @@ type Snapshot struct {
 }
 
 type Authentication struct {
+	// (Optional) When enabled, the operator auto-creates the password Secret.
+	// If passwordFromSecret is omitted, the Secret name defaults to <cluster-name>-password
+	// and the key defaults to "password". The generated Secret is retained if this is
+	// later disabled and is garbage-collected when the Dragonfly resource is deleted.
+	// +optional
+	// +kubebuilder:validation:Optional
+	AutoCreatePasswordSecret bool `json:"autoCreatePasswordSecret,omitempty"`
+
 	// (Optional) Dragonfly Password from Secret as a reference to a specific key
 	// +optional
 	PasswordFromSecret *corev1.SecretKeySelector `json:"passwordFromSecret,omitempty"`

--- a/charts/dragonfly-operator/templates/clusterroles.yaml
+++ b/charts/dragonfly-operator/templates/clusterroles.yaml
@@ -12,6 +12,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - secrets
     verbs:
       - create
       - delete

--- a/charts/dragonfly-operator/templates/crds.yaml
+++ b/charts/dragonfly-operator/templates/crds.yaml
@@ -4225,6 +4225,13 @@ spec:
               authentication:
                 description: (Optional) Dragonfly Authentication mechanism
                 properties:
+                  autoCreatePasswordSecret:
+                    description: |-
+                      (Optional) When enabled, the operator auto-creates the password Secret.
+                      If passwordFromSecret is omitted, the Secret name defaults to <cluster-name>-password
+                      and the key defaults to "password". The generated Secret is retained if this is
+                      later disabled and is garbage-collected when the Dragonfly resource is deleted.
+                    type: boolean
                   clientCaCertSecret:
                     description: |-
                       (Optional) If specified, the Dragonfly instance will check if the

--- a/charts/dragonfly-operator/templates/deployment.yaml
+++ b/charts/dragonfly-operator/templates/deployment.yaml
@@ -71,6 +71,7 @@ spec:
             - /manager
           args:
             - --leader-elect
+            - --cluster-domain={{ .Values.clusterDomain }}
             {{- if .Values.dragonflyImage }}
             - --dragonfly-image={{ .Values.dragonflyImage }}
             {{- end }}

--- a/charts/dragonfly-operator/templates/roles.yaml
+++ b/charts/dragonfly-operator/templates/roles.yaml
@@ -55,6 +55,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - secrets
     verbs:
       - create
       - delete
@@ -166,4 +167,3 @@ rules:
       - update
 {{- end }}
 {{- end }}
-

--- a/charts/dragonfly-operator/values.yaml
+++ b/charts/dragonfly-operator/values.yaml
@@ -18,6 +18,9 @@ namespaceOverride: ""
 # -- Default dragonfly image to use
 dragonflyImage: ""
 
+# -- Kubernetes cluster DNS domain used in generated connection URIs
+clusterDomain: cluster.local
+
 # -- Additional labels to add to all resources
 additionalLabels: {}
   # app: dragonfly-operator

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,7 @@ import (
 
 	dragonflydbiov1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
 	"github.com/dragonflydb/dragonfly-operator/internal/controller"
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -71,9 +72,11 @@ func main() {
 	var versionFlag bool
 	var watchCurrentNamespace bool
 	var dragonflyImage string
+	var clusterDomain string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&dragonflyImage, "dragonfly-image", "", "The default dragonfly image to use.")
+	flag.StringVar(&clusterDomain, "cluster-domain", resources.DefaultKubernetesClusterDomain, "The Kubernetes cluster DNS domain.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -159,6 +162,7 @@ func main() {
 			EventRecorder:         eventRecorder,
 			DefaultDragonflyImage: dragonflyImage,
 			OperatorNamespace:     operatorNamespace,
+			ClusterDomain:         clusterDomain,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Dragonfly")
@@ -172,6 +176,7 @@ func main() {
 			EventRecorder:         eventRecorder,
 			DefaultDragonflyImage: dragonflyImage,
 			OperatorNamespace:     operatorNamespace,
+			ClusterDomain:         clusterDomain,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Health")

--- a/config/crd/bases/dragonflydb.io_dragonflies.yaml
+++ b/config/crd/bases/dragonflydb.io_dragonflies.yaml
@@ -4427,6 +4427,13 @@ spec:
               authentication:
                 description: (Optional) Dragonfly Authentication mechanism
                 properties:
+                  autoCreatePasswordSecret:
+                    description: |-
+                      (Optional) When enabled, the operator auto-creates the password Secret.
+                      If passwordFromSecret is omitted, the Secret name defaults to <cluster-name>-password
+                      and the key defaults to "password". The generated Secret is retained if this is
+                      later disabled and is garbage-collected when the Dragonfly resource is deleted.
+                    type: boolean
                   clientCaCertSecret:
                     description: |-
                       (Optional) If specified, the Dragonfly instance will check if the

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -53,3 +53,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--cluster-domain=cluster.local"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --cluster-domain=cluster.local
         image: controller:latest
         name: manager
         env:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - pods
+  - secrets
   - services
   verbs:
   - create

--- a/config/samples/v1alpha1_dragonfly.yaml
+++ b/config/samples/v1alpha1_dragonfly.yaml
@@ -10,6 +10,8 @@ metadata:
   name: dragonfly-sample
 spec:
   replicas: 2
+  authentication:
+    autoCreatePasswordSecret: true
   resources:
     requests:
       cpu: 500m

--- a/e2e/dragonfly_controller_test.go
+++ b/e2e/dragonfly_controller_test.go
@@ -1041,6 +1041,158 @@ var _ = Describe("Dragonfly with additional container and volume", Ordered, Flak
 	})
 })
 
+var _ = Describe("Dragonfly auto-created password secret", Ordered, FlakeAttempts(3), func() {
+	ctx := context.Background()
+	name := "df-auto-password"
+	namespace := "default"
+
+	df := resourcesv1.Dragonfly{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: resourcesv1.DragonflySpec{
+			Replicas: 1,
+			Authentication: &resourcesv1.Authentication{
+				AutoCreatePasswordSecret: true,
+			},
+		},
+	}
+
+	Context("Generated secret lifecycle", func() {
+		It("creates the cluster and generated secret", func() {
+			Expect(k8sClient.Create(ctx, &df)).To(Succeed())
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseResourcesCreated, 2*time.Minute)).To(Succeed())
+			Expect(waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)).To(Succeed())
+			Expect(waitForMasterPod(ctx, k8sClient, name, namespace, 2*time.Minute)).To(Succeed())
+		})
+
+		It("creates a basic auth secret and uses it for connectivity", func() {
+			var secret corev1.Secret
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: name + "-password", Namespace: namespace}, &secret)
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+
+			Expect(secret.Type).To(Equal(corev1.SecretTypeBasicAuth))
+			Expect(secret.Data).To(HaveKey("username"))
+			Expect(secret.Data).To(HaveKey("user"))
+			Expect(secret.Data).To(HaveKey("password"))
+			Expect(secret.Data).To(HaveKey("host"))
+			Expect(secret.Data).To(HaveKey("port"))
+			Expect(secret.Data).To(HaveKey("uri"))
+			Expect(secret.Data).To(HaveKey("fqdn-uri"))
+			Expect(string(secret.Data["username"])).To(Equal("default"))
+			Expect(string(secret.Data["user"])).To(Equal("default"))
+			Expect(string(secret.Data["host"])).To(Equal(name))
+			Expect(string(secret.Data["port"])).To(Equal("6379"))
+			Expect(string(secret.Data["uri"])).To(ContainSubstring("redis://default:"))
+			Expect(string(secret.Data["uri"])).To(ContainSubstring("@" + name + ".default:6379"))
+			Expect(string(secret.Data["fqdn-uri"])).To(ContainSubstring("@" + name + ".default.svc.cluster.local:6379"))
+
+			stopChan := make(chan struct{}, 1)
+			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, string(secret.Data["password"]), 6397)
+			Expect(err).To(BeNil())
+			defer close(stopChan)
+			defer rc.Close()
+
+			Expect(rc.Set(ctx, "auto-secret", "ok", 0).Err()).To(BeNil())
+		})
+
+		It("rolls the cluster when the generated password changes", func() {
+			var statefulSet appsv1.StatefulSet
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &statefulSet)).To(Succeed())
+			oldHash := statefulSet.Spec.Template.Annotations[resources.GeneratedPasswordHashAnnotationKey]
+			Expect(oldHash).NotTo(BeEmpty())
+
+			var pods corev1.PodList
+			Expect(k8sClient.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
+				resources.DragonflyNameLabelKey: name,
+			})).To(Succeed())
+			Expect(pods.Items).To(HaveLen(1))
+			oldPodUID := pods.Items[0].UID
+
+			var secret corev1.Secret
+			secretKey := types.NamespacedName{Name: name + "-password", Namespace: namespace}
+			Expect(k8sClient.Get(ctx, secretKey, &secret)).To(Succeed())
+			secret.Data[resources.GeneratedPasswordSecretKey] = []byte("rotated-password")
+			Expect(k8sClient.Update(ctx, &secret)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &statefulSet)).To(Succeed())
+				g.Expect(statefulSet.Spec.Template.Annotations[resources.GeneratedPasswordHashAnnotationKey]).NotTo(Equal(oldHash))
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
+					resources.DragonflyNameLabelKey: name,
+				})).To(Succeed())
+				g.Expect(pods.Items).To(HaveLen(1))
+				g.Expect(pods.Items[0].UID).NotTo(Equal(oldPodUID))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+			Expect(waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)).To(Succeed())
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)).To(Succeed())
+			Expect(waitForMasterPod(ctx, k8sClient, name, namespace, 2*time.Minute)).To(Succeed())
+
+			stopChan := make(chan struct{}, 1)
+			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, "rotated-password", 6397)
+			Expect(err).To(BeNil())
+			defer close(stopChan)
+			defer rc.Close()
+			Expect(rc.Set(ctx, "auto-secret-rotated", "ok", 0).Err()).To(BeNil())
+		})
+
+		It("retains the generated secret when disabled", func() {
+			var pods corev1.PodList
+			Expect(k8sClient.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
+				resources.DragonflyNameLabelKey: name,
+			})).To(Succeed())
+			Expect(pods.Items).To(HaveLen(1))
+			oldPodUID := pods.Items[0].UID
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &df)).To(Succeed())
+			df.Spec.Authentication.AutoCreatePasswordSecret = false
+			Expect(k8sClient.Update(ctx, &df)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				var statefulSet appsv1.StatefulSet
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &statefulSet)).To(Succeed())
+				g.Expect(statefulSet.Spec.Template.Annotations).NotTo(HaveKey(resources.GeneratedPasswordHashAnnotationKey))
+			}, 1*time.Minute, 2*time.Second).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
+					resources.DragonflyNameLabelKey: name,
+				})).To(Succeed())
+				g.Expect(pods.Items).To(HaveLen(1))
+				g.Expect(pods.Items[0].UID).NotTo(Equal(oldPodUID))
+			}, 2*time.Minute, 2*time.Second).Should(Succeed())
+			Expect(waitForStatefulSetReady(ctx, k8sClient, name, namespace, 2*time.Minute)).To(Succeed())
+			Expect(waitForDragonflyPhase(ctx, k8sClient, name, namespace, controller.PhaseReady, 2*time.Minute)).To(Succeed())
+
+			Consistently(func() error {
+				var secret corev1.Secret
+				return k8sClient.Get(ctx, types.NamespacedName{Name: name + "-password", Namespace: namespace}, &secret)
+			}, 10*time.Second, 2*time.Second).Should(Succeed())
+
+			stopChan := make(chan struct{}, 1)
+			rc, err := checkAndK8sPortForwardRedis(ctx, clientset, cfg, stopChan, name, namespace, "", 6397)
+			Expect(err).To(BeNil())
+			defer close(stopChan)
+			defer rc.Close()
+			Expect(rc.Set(ctx, "auto-secret-disabled", "ok", 0).Err()).To(BeNil())
+		})
+
+		It("Cleanup", func() {
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &df)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, &df)).To(Succeed())
+			Eventually(func() bool {
+				var secret corev1.Secret
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-password", Namespace: namespace}, &secret)
+				return apierrors.IsNotFound(err)
+			}, 1*time.Minute, 2*time.Second).Should(BeTrue())
+		})
+	})
+})
+
 var _ = Describe("Dragonfly Server TLS tests", Ordered, FlakeAttempts(3), func() {
 	ctx := context.Background()
 	name := "df-tls"

--- a/internal/controller/base_controller.go
+++ b/internal/controller/base_controller.go
@@ -33,6 +33,7 @@ type Reconciler struct {
 	EventRecorder         record.EventRecorder
 	DefaultDragonflyImage string
 	OperatorNamespace     string
+	ClusterDomain         string
 }
 
 func (r *Reconciler) getDragonflyInstance(ctx context.Context, namespacedName types.NamespacedName, log logr.Logger) (*DragonflyInstance, error) {
@@ -51,5 +52,6 @@ func (r *Reconciler) getDragonflyInstance(ctx context.Context, namespacedName ty
 		eventRecorder:         r.EventRecorder,
 		defaultDragonflyImage: r.DefaultDragonflyImage,
 		operatorNamespace:     r.OperatorNamespace,
+		clusterDomain:         r.ClusterDomain,
 	}, nil
 }

--- a/internal/controller/dragonfly_controller.go
+++ b/internal/controller/dragonfly_controller.go
@@ -43,6 +43,7 @@ type DragonflyReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
@@ -160,6 +161,7 @@ func (r *DragonflyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}, builder.MatchEveryOwner).
 		Owns(&corev1.Service{}, builder.MatchEveryOwner).
 		Owns(&corev1.ConfigMap{}, builder.MatchEveryOwner).
+		Owns(&corev1.Secret{}, builder.MatchEveryOwner).
 		Owns(&networkingv1.NetworkPolicy{}, builder.MatchEveryOwner).
 		Named("Dragonfly").
 		Complete(r)

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -18,7 +18,12 @@ package controller
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	"maps"
 	"net"
 	"reflect"
 	"sort"
@@ -55,6 +60,7 @@ type DragonflyInstance struct {
 	eventRecorder         record.EventRecorder
 	defaultDragonflyImage string
 	operatorNamespace     string
+	clusterDomain         string
 	redisClients          map[string]*redis.Client
 }
 
@@ -621,6 +627,19 @@ func (dfi *DragonflyInstance) reconcileResources(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate dragonfly resources: %w", err)
 	}
+
+	generatedPasswordHash, err := dfi.reconcilePasswordSecret(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile password secret: %w", err)
+	}
+	if generatedPasswordHash != "" {
+		for _, resource := range dfResources {
+			if statefulSet, ok := resource.(*appsv1.StatefulSet); ok {
+				statefulSet.Spec.Template.Annotations[resources.GeneratedPasswordHashAnnotationKey] = generatedPasswordHash
+				break
+			}
+		}
+	}
 	for _, desired := range dfResources {
 		dfi.log.Info("reconciling dragonfly resource", "kind", getGVK(desired, dfi.scheme).Kind, "namespace", desired.GetNamespace(), "Name", desired.GetName())
 
@@ -763,6 +782,148 @@ func copyDesiredPayload(desired, existing client.Object) {
 	if desiredSpec.IsValid() && existingSpec.IsValid() {
 		existingSpec.Set(desiredSpec)
 	}
+}
+
+func (dfi *DragonflyInstance) reconcilePasswordSecret(ctx context.Context) (string, error) {
+	autoCreateEnabled := dfi.df.Spec.Authentication != nil && dfi.df.Spec.Authentication.AutoCreatePasswordSecret
+	hasExplicitPasswordSecret := dfi.df.Spec.Authentication != nil && dfi.df.Spec.Authentication.PasswordFromSecret != nil
+
+	if hasExplicitPasswordSecret {
+		if err := dfi.validatePasswordSecretTransition(ctx); err != nil {
+			return "", err
+		}
+		return "", nil
+	}
+	if !autoCreateEnabled {
+		return "", nil
+	}
+
+	secretName := resources.GetGeneratedPasswordSecretName(dfi.df)
+	var existing corev1.Secret
+	err := dfi.client.Get(ctx, client.ObjectKey{Namespace: dfi.df.Namespace, Name: secretName}, &existing)
+	secretExists := err == nil
+
+	password := ""
+	if secretExists {
+		if !metav1.IsControlledBy(&existing, dfi.df) {
+			return "", fmt.Errorf("secret %s already exists and is not controlled by Dragonfly %s", secretName, dfi.df.Name)
+		}
+		passwordBytes, ok := existing.Data[resources.GeneratedPasswordSecretKey]
+		if !ok || len(passwordBytes) == 0 {
+			return "", fmt.Errorf("generated password secret %s is missing %q", secretName, resources.GeneratedPasswordSecretKey)
+		}
+		password = string(passwordBytes)
+	} else if !apierrors.IsNotFound(err) {
+		return "", err
+	}
+
+	if password == "" {
+		password, err = generatePasswordSecretValue()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	secretData := maps.Clone(existing.Data)
+	if secretData == nil {
+		secretData = map[string][]byte{}
+	}
+	maps.Copy(secretData, resources.BuildAuthSecretData(dfi.df, password, dfi.clusterDomain))
+	passwordHash := hashGeneratedPassword(password)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        secretName,
+			Namespace:   dfi.df.Namespace,
+			Labels:      resources.GenerateOwnedResourceLabels(dfi.df),
+			Annotations: resources.GenerateOwnedResourceAnnotations(dfi.df),
+		},
+		Type: resources.GeneratedPasswordSecretType,
+		Data: secretData,
+	}
+
+	if err := controllerutil.SetControllerReference(dfi.df, secret, dfi.scheme); err != nil {
+		return "", fmt.Errorf("failed to set controller reference: %w", err)
+	}
+
+	if !secretExists {
+		if err := dfi.client.Create(ctx, secret); err != nil {
+			return "", err
+		}
+
+		dfi.log.Info("created generated password secret", "secret", secretName)
+		return passwordHash, nil
+	}
+
+	patch := client.MergeFrom(existing.DeepCopy())
+	oldType := existing.Type
+	oldData := existing.Data
+	oldLabels := existing.Labels
+	oldAnnotations := existing.Annotations
+	oldOwnerReferences := existing.OwnerReferences
+
+	existing.Type = secret.Type
+	existing.Data = secret.Data
+	existing.Labels = secret.Labels
+	existing.Annotations = secret.Annotations
+	existing.OwnerReferences = secret.OwnerReferences
+
+	if oldType == existing.Type &&
+		reflect.DeepEqual(oldData, existing.Data) &&
+		reflect.DeepEqual(oldLabels, existing.Labels) &&
+		reflect.DeepEqual(oldAnnotations, existing.Annotations) &&
+		reflect.DeepEqual(oldOwnerReferences, existing.OwnerReferences) {
+		return passwordHash, nil
+	}
+
+	if err := dfi.client.Patch(ctx, &existing, patch); err != nil {
+		return "", err
+	}
+
+	dfi.log.Info("updated generated password secret", "secret", secretName)
+	return passwordHash, nil
+}
+
+func (dfi *DragonflyInstance) validatePasswordSecretTransition(ctx context.Context) error {
+	var generated corev1.Secret
+	err := dfi.client.Get(ctx, client.ObjectKey{
+		Namespace: dfi.df.Namespace,
+		Name:      resources.GetGeneratedPasswordSecretName(dfi.df),
+	}, &generated)
+	if apierrors.IsNotFound(err) || (err == nil && !metav1.IsControlledBy(&generated, dfi.df)) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	selector := dfi.df.Spec.Authentication.PasswordFromSecret
+	if selector.Name == "" || selector.Key == "" {
+		return fmt.Errorf("passwordFromSecret name and key must be set before replacing generated credentials")
+	}
+
+	var explicit corev1.Secret
+	if err := dfi.client.Get(ctx, client.ObjectKey{Namespace: dfi.df.Namespace, Name: selector.Name}, &explicit); err != nil {
+		return fmt.Errorf("cannot replace generated credentials: %w", err)
+	}
+	if value, ok := explicit.Data[selector.Key]; !ok || len(value) == 0 {
+		return fmt.Errorf("cannot replace generated credentials: secret %s is missing non-empty key %q", selector.Name, selector.Key)
+	}
+	return nil
+}
+
+func hashGeneratedPassword(password string) string {
+	digest := sha256.Sum256([]byte(password))
+	return hex.EncodeToString(digest[:])
+}
+
+func generatePasswordSecretValue() (string, error) {
+	payload := make([]byte, 24)
+	if _, err := rand.Read(payload); err != nil {
+		return "", fmt.Errorf("failed to generate password: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(payload), nil
 }
 
 // Helper function to compare resource specs (add to the file)

--- a/internal/controller/dragonfly_instance_password_secret_test.go
+++ b/internal/controller/dragonfly_instance_password_secret_test.go
@@ -1,0 +1,417 @@
+package controller
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	dfv1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestReconcilePasswordSecretCreatesGeneratedSecret(t *testing.T) {
+	ctx := context.Background()
+	dfi, c := newPasswordSecretTestInstance(t, &dfv1alpha1.Dragonfly{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "dragonflydb.io/v1alpha1",
+			Kind:       "Dragonfly",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "df-auto-secret",
+			Namespace: "default",
+			UID:       types.UID("df-auto-secret-uid"),
+		},
+		Spec: dfv1alpha1.DragonflySpec{
+			Replicas: 1,
+			Authentication: &dfv1alpha1.Authentication{
+				AutoCreatePasswordSecret: true,
+			},
+		},
+	})
+
+	passwordHash, err := dfi.reconcilePasswordSecret(ctx)
+	if err != nil {
+		t.Fatalf("reconcilePasswordSecret() error = %v", err)
+	}
+	if passwordHash == "" {
+		t.Fatal("reconcilePasswordSecret() returned an empty password hash")
+	}
+
+	var secret corev1.Secret
+	if err := c.Get(ctx, ctrlclient.ObjectKey{Namespace: "default", Name: "df-auto-secret-password"}, &secret); err != nil {
+		t.Fatalf("generated secret not found: %v", err)
+	}
+
+	if secret.Type != resources.GeneratedPasswordSecretType {
+		t.Fatalf("unexpected secret type %q", secret.Type)
+	}
+	if secret.Data[resources.GeneratedPasswordUsernameKey] == nil {
+		t.Fatalf("generated secret is missing %q", resources.GeneratedPasswordUsernameKey)
+	}
+	if string(secret.Data[resources.GeneratedPasswordUsernameKey]) != resources.GeneratedPasswordUsername {
+		t.Fatalf("unexpected username %q", string(secret.Data[resources.GeneratedPasswordUsernameKey]))
+	}
+	if string(secret.Data[resources.GeneratedPasswordUserKey]) != resources.GeneratedPasswordUsername {
+		t.Fatalf("unexpected user %q", string(secret.Data[resources.GeneratedPasswordUserKey]))
+	}
+	if len(secret.Data[resources.GeneratedPasswordSecretKey]) == 0 {
+		t.Fatalf("generated secret is missing %q", resources.GeneratedPasswordSecretKey)
+	}
+	if string(secret.Data[resources.GeneratedPasswordHostKey]) != "df-auto-secret" {
+		t.Fatalf("unexpected host %q", string(secret.Data[resources.GeneratedPasswordHostKey]))
+	}
+	if string(secret.Data[resources.GeneratedPasswordPortKey]) != "6379" {
+		t.Fatalf("unexpected port %q", string(secret.Data[resources.GeneratedPasswordPortKey]))
+	}
+	if len(secret.Data[resources.GeneratedPasswordURIKey]) == 0 {
+		t.Fatalf("generated secret is missing %q", resources.GeneratedPasswordURIKey)
+	}
+	if len(secret.Data[resources.GeneratedPasswordFQDNURIKey]) == 0 {
+		t.Fatalf("generated secret is missing %q", resources.GeneratedPasswordFQDNURIKey)
+	}
+	if !metav1.IsControlledBy(&secret, dfi.df) {
+		t.Fatalf("generated secret should be owned by dragonfly")
+	}
+}
+
+func TestReconcilePasswordSecretRetainsOwnedGeneratedSecretWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	df := &dfv1alpha1.Dragonfly{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "dragonflydb.io/v1alpha1",
+			Kind:       "Dragonfly",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "df-auto-secret",
+			Namespace: "default",
+			UID:       types.UID("df-auto-secret-uid"),
+		},
+		Spec: dfv1alpha1.DragonflySpec{
+			Replicas: 1,
+		},
+	}
+
+	ownedSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "df-auto-secret-password",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: df.APIVersion,
+				Kind:       df.Kind,
+				Name:       df.Name,
+				UID:        df.UID,
+				Controller: boolPtr(true),
+			}},
+		},
+		Type: corev1.SecretTypeBasicAuth,
+		Data: map[string][]byte{resources.GeneratedPasswordSecretKey: []byte("secret")},
+	}
+
+	dfi, c := newPasswordSecretTestInstance(t, df, &ownedSecret)
+
+	passwordHash, err := dfi.reconcilePasswordSecret(ctx)
+	if err != nil {
+		t.Fatalf("reconcilePasswordSecret() error = %v", err)
+	}
+	if passwordHash != "" {
+		t.Fatalf("expected no active generated password hash, got %q", passwordHash)
+	}
+
+	var secret corev1.Secret
+	if err := c.Get(ctx, ctrlclient.ObjectKey{Namespace: "default", Name: "df-auto-secret-password"}, &secret); err != nil {
+		t.Fatalf("expected generated secret to be retained: %v", err)
+	}
+}
+
+func TestReconcilePasswordSecretRejectsUnownedNameCollision(t *testing.T) {
+	df := newPasswordSecretTestDragonfly()
+	unownedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "df-auto-secret-password", Namespace: "default"},
+		Data:       map[string][]byte{resources.GeneratedPasswordSecretKey: []byte("unowned")},
+	}
+	dfi, _ := newPasswordSecretTestInstance(t, df, unownedSecret)
+
+	_, err := dfi.reconcilePasswordSecret(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "is not controlled") {
+		t.Fatalf("expected ownership collision error, got %v", err)
+	}
+}
+
+func TestReconcileResourcesKeepsGeneratedCredentialsWhenExplicitSecretIsInvalid(t *testing.T) {
+	ctx := context.Background()
+	df := newPasswordSecretTestDragonfly()
+	dfi, c := newPasswordSecretTestInstance(t, df)
+
+	if err := dfi.reconcileResources(ctx); err != nil {
+		t.Fatalf("initial reconcileResources() error = %v", err)
+	}
+	var statefulSet appsv1.StatefulSet
+	key := ctrlclient.ObjectKey{Namespace: df.Namespace, Name: df.Name}
+	if err := c.Get(ctx, key, &statefulSet); err != nil {
+		t.Fatalf("statefulset not found: %v", err)
+	}
+	originalSpec := statefulSet.Spec.DeepCopy()
+
+	df.Spec.Authentication.PasswordFromSecret = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: "missing-secret"},
+		Key:                  "password",
+	}
+	if err := dfi.reconcileResources(ctx); err == nil {
+		t.Fatal("expected invalid explicit secret transition to fail")
+	}
+	if err := c.Get(ctx, key, &statefulSet); err != nil {
+		t.Fatalf("statefulset not found after failed transition: %v", err)
+	}
+	if !reflect.DeepEqual(originalSpec, &statefulSet.Spec) {
+		t.Fatal("failed explicit secret transition changed the statefulset")
+	}
+	var generated corev1.Secret
+	if err := c.Get(ctx, ctrlclient.ObjectKey{
+		Namespace: df.Namespace, Name: resources.GetGeneratedPasswordSecretName(df),
+	}, &generated); err != nil {
+		t.Fatalf("failed explicit secret transition removed generated credentials: %v", err)
+	}
+}
+
+func TestReconcileResourcesSwitchesToExplicitSecretAndRetainsGeneratedSecret(t *testing.T) {
+	ctx := context.Background()
+	df := newPasswordSecretTestDragonfly()
+	dfi, c := newPasswordSecretTestInstance(t, df)
+
+	if err := dfi.reconcileResources(ctx); err != nil {
+		t.Fatalf("initial reconcileResources() error = %v", err)
+	}
+	explicit := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "explicit-password", Namespace: df.Namespace},
+		Data:       map[string][]byte{"secret-key": []byte("external-password")},
+	}
+	if err := c.Create(ctx, explicit); err != nil {
+		t.Fatalf("failed to create explicit password secret: %v", err)
+	}
+	df.Spec.Authentication.PasswordFromSecret = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: explicit.Name},
+		Key:                  "secret-key",
+	}
+
+	if err := dfi.reconcileResources(ctx); err != nil {
+		t.Fatalf("reconcileResources() during explicit secret transition error = %v", err)
+	}
+	var statefulSet appsv1.StatefulSet
+	if err := c.Get(ctx, ctrlclient.ObjectKey{Namespace: df.Namespace, Name: df.Name}, &statefulSet); err != nil {
+		t.Fatalf("statefulset not found: %v", err)
+	}
+	if _, ok := statefulSet.Spec.Template.Annotations[resources.GeneratedPasswordHashAnnotationKey]; ok {
+		t.Fatal("generated password hash annotation was not removed")
+	}
+	foundExplicitSelector := false
+	for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "DFLY_requirepass" && env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+			foundExplicitSelector = env.ValueFrom.SecretKeyRef.Name == explicit.Name && env.ValueFrom.SecretKeyRef.Key == "secret-key"
+		}
+	}
+	if !foundExplicitSelector {
+		t.Fatal("statefulset does not reference the explicit password secret")
+	}
+	var generated corev1.Secret
+	if err := c.Get(ctx, ctrlclient.ObjectKey{
+		Namespace: df.Namespace, Name: resources.GetGeneratedPasswordSecretName(df),
+	}, &generated); err != nil {
+		t.Fatalf("generated secret was not retained: %v", err)
+	}
+}
+
+func TestReconcileResourcesRollsPodsWhenGeneratedPasswordChanges(t *testing.T) {
+	ctx := context.Background()
+	df := newPasswordSecretTestDragonfly()
+	dfi, c := newPasswordSecretTestInstance(t, df)
+
+	if err := dfi.reconcileResources(ctx); err != nil {
+		t.Fatalf("initial reconcileResources() error = %v", err)
+	}
+
+	var statefulSet appsv1.StatefulSet
+	key := ctrlclient.ObjectKey{Namespace: df.Namespace, Name: df.Name}
+	if err := c.Get(ctx, key, &statefulSet); err != nil {
+		t.Fatalf("statefulset not found: %v", err)
+	}
+	oldHash := statefulSet.Spec.Template.Annotations[resources.GeneratedPasswordHashAnnotationKey]
+	if oldHash == "" {
+		t.Fatal("statefulset is missing generated password hash annotation")
+	}
+
+	var secret corev1.Secret
+	secretKey := ctrlclient.ObjectKey{Namespace: df.Namespace, Name: resources.GetGeneratedPasswordSecretName(df)}
+	if err := c.Get(ctx, secretKey, &secret); err != nil {
+		t.Fatalf("generated secret not found: %v", err)
+	}
+	secret.Data[resources.GeneratedPasswordSecretKey] = []byte("rotated-password")
+	if err := c.Update(ctx, &secret); err != nil {
+		t.Fatalf("failed to rotate generated password: %v", err)
+	}
+
+	if err := dfi.reconcileResources(ctx); err != nil {
+		t.Fatalf("reconcileResources() after rotation error = %v", err)
+	}
+	if err := c.Get(ctx, key, &statefulSet); err != nil {
+		t.Fatalf("statefulset not found after rotation: %v", err)
+	}
+	newHash := statefulSet.Spec.Template.Annotations[resources.GeneratedPasswordHashAnnotationKey]
+	if newHash == oldHash {
+		t.Fatalf("generated password rotation did not change pod template hash %q", newHash)
+	}
+	if strings.Contains(newHash, "rotated-password") {
+		t.Fatal("generated password hash annotation contains the plaintext password")
+	}
+
+	df.Spec.Authentication.AutoCreatePasswordSecret = false
+	if err := dfi.reconcileResources(ctx); err != nil {
+		t.Fatalf("reconcileResources() after disabling generation error = %v", err)
+	}
+	if err := c.Get(ctx, key, &statefulSet); err != nil {
+		t.Fatalf("statefulset not found after disabling generation: %v", err)
+	}
+	if _, ok := statefulSet.Spec.Template.Annotations[resources.GeneratedPasswordHashAnnotationKey]; ok {
+		t.Fatal("generated password hash annotation was not removed")
+	}
+	if err := c.Get(ctx, secretKey, &secret); err != nil {
+		t.Fatalf("generated secret was not retained: %v", err)
+	}
+}
+
+func TestReconcilePasswordSecretRecreatesDeletedSecretWithNewHash(t *testing.T) {
+	ctx := context.Background()
+	df := newPasswordSecretTestDragonfly()
+	dfi, c := newPasswordSecretTestInstance(t, df)
+
+	oldHash, err := dfi.reconcilePasswordSecret(ctx)
+	if err != nil {
+		t.Fatalf("initial reconcilePasswordSecret() error = %v", err)
+	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: resources.GetGeneratedPasswordSecretName(df), Namespace: df.Namespace,
+	}}
+	if err := c.Delete(ctx, secret); err != nil {
+		t.Fatalf("failed to delete generated secret: %v", err)
+	}
+	if err := c.Get(ctx, ctrlclient.ObjectKeyFromObject(secret), secret); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected generated secret to be deleted, got %v", err)
+	}
+
+	newHash, err := dfi.reconcilePasswordSecret(ctx)
+	if err != nil {
+		t.Fatalf("reconcilePasswordSecret() after deletion error = %v", err)
+	}
+	if newHash == oldHash {
+		t.Fatalf("recreated secret reused password hash %q", newHash)
+	}
+}
+
+func TestReconcilePasswordSecretPreservesCustomData(t *testing.T) {
+	ctx := context.Background()
+	df := newPasswordSecretTestDragonfly()
+	dfi, c := newPasswordSecretTestInstance(t, df)
+
+	originalHash, err := dfi.reconcilePasswordSecret(ctx)
+	if err != nil {
+		t.Fatalf("initial reconcilePasswordSecret() error = %v", err)
+	}
+	var secret corev1.Secret
+	key := ctrlclient.ObjectKey{Namespace: df.Namespace, Name: resources.GetGeneratedPasswordSecretName(df)}
+	if err := c.Get(ctx, key, &secret); err != nil {
+		t.Fatalf("generated secret not found: %v", err)
+	}
+	secret.Data["application-config"] = []byte("preserve-me")
+	if err := c.Update(ctx, &secret); err != nil {
+		t.Fatalf("failed to add custom secret data: %v", err)
+	}
+
+	reconciledHash, err := dfi.reconcilePasswordSecret(ctx)
+	if err != nil {
+		t.Fatalf("reconcilePasswordSecret() error = %v", err)
+	}
+	if reconciledHash != originalHash {
+		t.Fatalf("custom data changed generated password hash from %q to %q", originalHash, reconciledHash)
+	}
+	if err := c.Get(ctx, key, &secret); err != nil {
+		t.Fatalf("generated secret not found after reconcile: %v", err)
+	}
+	if string(secret.Data["application-config"]) != "preserve-me" {
+		t.Fatal("reconcile removed custom secret data")
+	}
+}
+
+func TestReconcileResourcesValidatesBeforeCreatingSecret(t *testing.T) {
+	ctx := context.Background()
+	df := newPasswordSecretTestDragonfly()
+	df.Spec.OwnedObjectsMetadata = &dfv1alpha1.MetadataSpec{
+		Labels: map[string]string{resources.DragonflyNameLabelKey: "override"},
+	}
+	dfi, c := newPasswordSecretTestInstance(t, df)
+
+	if err := dfi.reconcileResources(ctx); err == nil {
+		t.Fatal("expected invalid owned resource metadata to fail")
+	}
+	var secret corev1.Secret
+	err := c.Get(ctx, ctrlclient.ObjectKey{
+		Namespace: df.Namespace, Name: resources.GetGeneratedPasswordSecretName(df),
+	}, &secret)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("invalid specification created a generated secret: %v", err)
+	}
+}
+
+func newPasswordSecretTestDragonfly() *dfv1alpha1.Dragonfly {
+	return &dfv1alpha1.Dragonfly{
+		TypeMeta: metav1.TypeMeta{APIVersion: "dragonflydb.io/v1alpha1", Kind: "Dragonfly"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "df-auto-secret", Namespace: "default", UID: types.UID("df-auto-secret-uid"),
+		},
+		Spec: dfv1alpha1.DragonflySpec{
+			Replicas: 1,
+			Authentication: &dfv1alpha1.Authentication{
+				AutoCreatePasswordSecret: true,
+			},
+		},
+		Status: dfv1alpha1.DragonflyStatus{Phase: PhaseResourcesCreated},
+	}
+}
+
+func newPasswordSecretTestInstance(t *testing.T, df *dfv1alpha1.Dragonfly, initObjs ...ctrlclient.Object) (*DragonflyInstance, ctrlclient.Client) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := dfv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add dragonfly scheme: %v", err)
+	}
+
+	objs := append([]ctrlclient.Object{df}, initObjs...)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	return &DragonflyInstance{
+		df:            df,
+		client:        c,
+		log:           log.Log,
+		scheme:        scheme,
+		eventRecorder: record.NewFakeRecorder(8),
+		clusterDomain: resources.DefaultKubernetesClusterDomain,
+	}, c
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/internal/resources/const.go
+++ b/internal/resources/const.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package resources
 
-import "fmt"
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 	// DragonflyPortName is the name of the port on which the Dragonfly instance listens
@@ -87,7 +91,8 @@ const (
 	MasterIpLabelKey      = "master-ip"
 	DragonflyNameLabelKey = "app"
 
-	MasterIpAnnotationKey = "operator.dragonflydb.io/masterIP"
+	MasterIpAnnotationKey              = "operator.dragonflydb.io/masterIP"
+	GeneratedPasswordHashAnnotationKey = "operator.dragonflydb.io/generated-password-hash"
 
 	RoleLabelKey = "role"
 
@@ -121,6 +126,18 @@ const (
 	LivenessProbeVolumeName  = "liveness-probe"
 	ReadinessProbeVolumeName = "readiness-probe"
 	StartupProbeVolumeName   = "startup-probe"
+
+	GeneratedPasswordSecretSuffix  = "-password"
+	GeneratedPasswordSecretKey     = "password"
+	GeneratedPasswordSecretType    = corev1.SecretTypeBasicAuth
+	GeneratedPasswordUserKey       = "user"
+	GeneratedPasswordUsernameKey   = "username"
+	GeneratedPasswordUsername      = "default"
+	GeneratedPasswordHostKey       = "host"
+	GeneratedPasswordPortKey       = "port"
+	GeneratedPasswordURIKey        = "uri"
+	GeneratedPasswordFQDNURIKey    = "fqdn-uri"
+	DefaultKubernetesClusterDomain = "cluster.local"
 )
 
 var DefaultDragonflyArgs = []string{

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -19,6 +19,8 @@ package resources
 import (
 	"fmt"
 	"maps"
+	"net/url"
+	"strings"
 
 	resourcesv1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,6 +31,80 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func GetAuthPasswordSecretSelector(df *resourcesv1.Dragonfly) *corev1.SecretKeySelector {
+	if df.Spec.Authentication == nil {
+		return nil
+	}
+
+	if df.Spec.Authentication.PasswordFromSecret != nil {
+		return df.Spec.Authentication.PasswordFromSecret.DeepCopy()
+	}
+
+	if !df.Spec.Authentication.AutoCreatePasswordSecret {
+		return nil
+	}
+
+	return &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: GetGeneratedPasswordSecretName(df),
+		},
+		Key: GeneratedPasswordSecretKey,
+	}
+}
+
+func GetGeneratedPasswordSecretName(df *resourcesv1.Dragonfly) string {
+	return df.Name + GeneratedPasswordSecretSuffix
+}
+
+func GetServiceName(df *resourcesv1.Dragonfly) string {
+	serviceName := df.Name
+	if df.Spec.ServiceSpec != nil && df.Spec.ServiceSpec.Name != "" {
+		serviceName = df.Spec.ServiceSpec.Name
+	}
+	return serviceName
+}
+
+func BuildAuthSecretData(df *resourcesv1.Dragonfly, password, clusterDomain string) map[string][]byte {
+	host := GetServiceName(df)
+	port := fmt.Sprintf("%d", DragonflyPort)
+	user := GeneratedPasswordUsername
+	scheme := "redis"
+	if df.Spec.TLSSecretRef != nil {
+		scheme = "rediss"
+	}
+	if clusterDomain == "" {
+		clusterDomain = DefaultKubernetesClusterDomain
+	}
+	clusterDomain = strings.TrimSuffix(clusterDomain, ".")
+	shortURI := buildRedisURI(scheme, user, password, host, df.Namespace, "")
+	fqdnURI := buildRedisURI(scheme, user, password, host, df.Namespace, clusterDomain)
+
+	return map[string][]byte{
+		GeneratedPasswordUsernameKey: []byte(user),
+		GeneratedPasswordUserKey:     []byte(user),
+		GeneratedPasswordSecretKey:   []byte(password),
+		GeneratedPasswordHostKey:     []byte(host),
+		GeneratedPasswordPortKey:     []byte(port),
+		GeneratedPasswordURIKey:      []byte(shortURI),
+		GeneratedPasswordFQDNURIKey:  []byte(fqdnURI),
+	}
+}
+
+func buildRedisURI(scheme, user, password, serviceName, namespace, clusterDomain string) string {
+	host := fmt.Sprintf("%s.%s", serviceName, namespace)
+	if clusterDomain != "" {
+		host = fmt.Sprintf("%s.svc.%s", host, clusterDomain)
+	}
+
+	uri := &url.URL{
+		Scheme: scheme,
+		User:   url.UserPassword(user, password),
+		Host:   fmt.Sprintf("%s:%d", host, DragonflyPort),
+	}
+
+	return uri.String()
+}
 
 var (
 	dflyUserGroup int64 = 999
@@ -481,12 +557,12 @@ func GenerateDragonflyResources(df *resourcesv1.Dragonfly, defaultDragonflyImage
 	}
 
 	if df.Spec.Authentication != nil {
-		if df.Spec.Authentication.PasswordFromSecret != nil {
+		if passwordSecret := GetAuthPasswordSecretSelector(df); passwordSecret != nil {
 			// load the secret key as a password into env
 			statefulset.Spec.Template.Spec.Containers[0].Env = append(statefulset.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name: "DFLY_requirepass",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: df.Spec.Authentication.PasswordFromSecret,
+					SecretKeyRef: passwordSecret,
 				},
 			})
 		}
@@ -569,10 +645,7 @@ func GenerateDragonflyResources(df *resourcesv1.Dragonfly, defaultDragonflyImage
 
 	resources = append(resources, &statefulset)
 
-	serviceName := df.Name
-	if df.Spec.ServiceSpec != nil && df.Spec.ServiceSpec.Name != "" {
-		serviceName = df.Spec.ServiceSpec.Name
-	}
+	serviceName := GetServiceName(df)
 
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -807,6 +880,10 @@ func generateResourceLabels(df *resourcesv1.Dragonfly) map[string]string {
 	return labels
 }
 
+func GenerateOwnedResourceLabels(df *resourcesv1.Dragonfly) map[string]string {
+	return generateResourceLabels(df)
+}
+
 func generateResourceAnnotations(df *resourcesv1.Dragonfly) map[string]string {
 	annotations := map[string]string{}
 	if df.Spec.OwnedObjectsMetadata != nil {
@@ -814,4 +891,8 @@ func generateResourceAnnotations(df *resourcesv1.Dragonfly) map[string]string {
 	}
 
 	return annotations
+}
+
+func GenerateOwnedResourceAnnotations(df *resourcesv1.Dragonfly) map[string]string {
+	return generateResourceAnnotations(df)
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -131,6 +131,104 @@ func TestGenerateDragonflyResources_ReadinessGateEnabled(t *testing.T) {
 	t.Fatal("StatefulSet not found in generated resources")
 }
 
+func TestGetAuthPasswordSecretSelector(t *testing.T) {
+	t.Run("returns nil when auth disabled", func(t *testing.T) {
+		df := newTestDragonfly(1)
+
+		assert.Nil(t, GetAuthPasswordSecretSelector(df))
+	})
+
+	t.Run("returns explicit secret selector", func(t *testing.T) {
+		df := newTestDragonfly(1)
+		df.Spec.Authentication = &resourcesv1.Authentication{
+			PasswordFromSecret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "user-secret"},
+				Key:                  "custom-password",
+			},
+			AutoCreatePasswordSecret: true,
+		}
+
+		selector := GetAuthPasswordSecretSelector(df)
+		require.NotNil(t, selector)
+		assert.Equal(t, "user-secret", selector.Name)
+		assert.Equal(t, "custom-password", selector.Key)
+	})
+
+	t.Run("returns generated secret selector when enabled", func(t *testing.T) {
+		df := newTestDragonfly(1)
+		df.Spec.Authentication = &resourcesv1.Authentication{
+			AutoCreatePasswordSecret: true,
+		}
+
+		selector := GetAuthPasswordSecretSelector(df)
+		require.NotNil(t, selector)
+		assert.Equal(t, "test-df-password", selector.Name)
+		assert.Equal(t, GeneratedPasswordSecretKey, selector.Key)
+	})
+}
+
+func TestGenerateDragonflyResources_AutoCreatePasswordSecret(t *testing.T) {
+	df := newTestDragonfly(1)
+	df.Spec.Authentication = &resourcesv1.Authentication{
+		AutoCreatePasswordSecret: true,
+	}
+
+	resources, err := GenerateDragonflyResources(df, "", "")
+	require.NoError(t, err)
+
+	for _, obj := range resources {
+		if sts, ok := obj.(*appsv1.StatefulSet); ok {
+			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+			assert.Contains(t, sts.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+				Name: "DFLY_requirepass",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-df-password"},
+						Key:                  GeneratedPasswordSecretKey,
+					},
+				},
+			})
+			return
+		}
+	}
+
+	t.Fatal("StatefulSet not found in generated resources")
+}
+
+func TestBuildAuthSecretData(t *testing.T) {
+	df := newTestDragonfly(1)
+	data := BuildAuthSecretData(df, "secret-pass", "")
+
+	assert.Equal(t, "default", string(data[GeneratedPasswordUsernameKey]))
+	assert.Equal(t, "default", string(data[GeneratedPasswordUserKey]))
+	assert.Equal(t, "secret-pass", string(data[GeneratedPasswordSecretKey]))
+	assert.Equal(t, "test-df", string(data[GeneratedPasswordHostKey]))
+	assert.Equal(t, "6379", string(data[GeneratedPasswordPortKey]))
+	assert.Equal(t, "redis://default:secret-pass@test-df.default:6379", string(data[GeneratedPasswordURIKey]))
+	assert.Equal(t, "redis://default:secret-pass@test-df.default.svc.cluster.local:6379", string(data[GeneratedPasswordFQDNURIKey]))
+}
+
+func TestBuildAuthSecretData_UsesCustomServiceName(t *testing.T) {
+	df := newTestDragonfly(1)
+	df.Spec.ServiceSpec = &resourcesv1.ServiceSpec{Name: "dragonfly-rw"}
+
+	data := BuildAuthSecretData(df, "secret-pass", "corp.internal")
+
+	assert.Equal(t, "dragonfly-rw", string(data[GeneratedPasswordHostKey]))
+	assert.Equal(t, "redis://default:secret-pass@dragonfly-rw.default:6379", string(data[GeneratedPasswordURIKey]))
+	assert.Equal(t, "redis://default:secret-pass@dragonfly-rw.default.svc.corp.internal:6379", string(data[GeneratedPasswordFQDNURIKey]))
+}
+
+func TestBuildAuthSecretData_TLS(t *testing.T) {
+	df := newTestDragonfly(1)
+	df.Spec.TLSSecretRef = &corev1.SecretReference{Name: "dragonfly-tls"}
+
+	data := BuildAuthSecretData(df, "secret-pass", "cluster.example.")
+
+	assert.Equal(t, "rediss://default:secret-pass@test-df.default:6379", string(data[GeneratedPasswordURIKey]))
+	assert.Equal(t, "rediss://default:secret-pass@test-df.default.svc.cluster.example:6379", string(data[GeneratedPasswordFQDNURIKey]))
+}
+
 func findNetworkPolicy(objs []client.Object) *networkingv1.NetworkPolicy {
 	for _, obj := range objs {
 		if np, ok := obj.(*networkingv1.NetworkPolicy); ok {

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -118,8 +118,9 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -175,6 +176,43 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -237,14 +275,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                        will be reported as an event when the container is starting. When a key exists in multiple
+                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                        When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -265,8 +303,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -529,6 +568,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -899,7 +944,9 @@ spec:
                           type: integer
                       type: object
                     resizePolicy:
-                      description: Resources resize policy for the container.
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
                         description: ContainerResizePolicy represents resource resize
                           policy for the container.
@@ -931,7 +978,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This is an alpha field and requires enabling the
+                            This field depends on the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -985,10 +1032,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This field may only be set for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
+                        This overrides the pod-level restart policy. When this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                        have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -1000,6 +1047,59 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
+                    restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit. The rules are evaluated in
+                        order. Once a rule matches a container exit condition, the remaining
+                        rules are ignored. If no rule matches the container exit condition,
+                        the Container-level restart policy determines the whether the container
+                        is restarted or not. Constraints on the rules:
+                        - At most 20 rules are allowed.
+                        - Rules can have the same action.
+                        - Identical rules are not forbidden in validations.
+                        When rules are specified, container MUST set RestartPolicy explicitly
+                        even it if matches the Pod's RestartPolicy.
+                      items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
+                        properties:
+                          action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied. The only possible value is "Restart" to restart the
+                              container.
+                            type: string
+                          exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
+                            properties:
+                              operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values. Possible values are:
+                                  - In: the requirement is satisfied if the container exit code is in the
+                                    set of specified values.
+                                  - NotIn: the requirement is satisfied if the container exit code is
+                                    not in the set of specified values.
+                                type: string
+                              values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                            - operator
+                            type: object
+                        required:
+                        - action
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -1075,7 +1175,6 @@ spec:
                             procMount denotes the type of proc mount to use for the containers.
                             The default value is Default which uses the container runtime defaults for
                             readonly paths and masked paths.
-                            This requires the ProcMountType feature flag to be enabled.
                             Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
@@ -2084,7 +2183,7 @@ spec:
                                 resources:
                                   description: |-
                                     resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    Users are allowed to specify resource requirements
                                     that are lower than previous value but must still be higher than capacity recorded in the
                                     status field of the claim.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -2172,15 +2271,13 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
+                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                    this field can be reset to its previous value (including nil) to cancel the modification.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -2362,12 +2459,10 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
                           type: string
                         path:
                           description: |-
@@ -2420,8 +2515,8 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        The volume will be mounted read-only (ro).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:
@@ -2446,7 +2541,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -2592,8 +2687,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-
@@ -2866,6 +2960,129 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
+                              podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or server.
+
+                                  Kubelet generates a private key and uses it to send a
+                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                  request and issues a certificate chain, Kubelet writes the key and
+                                  certificate chain to the pod filesystem.  The pod does not start until
+                                  certificates have been issued for each podCertificate projected volume
+                                  source in its spec.
+
+                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                  timestamp.
+
+                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                  field, or separate files, indicated by the keyPath and
+                                  certificateChainPath fields.
+
+                                  The credential bundle is a single file in PEM format.  The first PEM
+                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                  entries are the certificate chain issued by the signer (typically,
+                                  signers will return their certificate chain in leaf-to-root order).
+
+                                  Prefer using the credential bundle format, since your application code
+                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                  your application must make two separate file reads. If these coincide
+                                  with a certificate rotation, it is possible that the private key and leaf
+                                  certificate you read may not correspond to each other.  Your application
+                                  will need to check for this condition, and re-read until they are
+                                  consistent.
+
+                                  The named signer controls chooses the format of the certificate it
+                                  issues; consult the signer implementation's documentation to learn how to
+                                  use the certificates it issues.
+                                properties:
+                                  certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  credentialBundlePath:
+                                    description: |-
+                                      Write the credential bundle at this path in the projected volume.
+
+                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                      key.
+
+                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                      certificate chain from the signer (leaf and any intermediates).
+
+                                      Using credentialBundlePath lets your Pod's application code make a single
+                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                      project them to separate files, your application code will need to
+                                      additionally check that the leaf certificate was issued to the key.
+                                    type: string
+                                  keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  keyType:
+                                    description: |-
+                                      The type of keypair Kubelet will generate for the pod.
+
+                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                      "ECDSAP521", and "ED25519".
+                                    type: string
+                                  maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
+
+                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                      generates for this projection.
+
+                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                      value is 7862400 (91 days).
+
+                                      The signer implementation is then free to issue a certificate with any
+                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                      longer than 24 hours.
+                                    format: int32
+                                    type: integer
+                                  signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
+                                    type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                      metadata in any way.
+
+                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                      Entries are subject to the same validation as object metadata annotations,
+                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                      are placed on values, except an overall size limitation on the entire field.
+
+                                      Signers should document the keys and values they support. Signers should
+                                      deny requests that contain keys they do not recognize.
+                                    type: object
+                                required:
+                                - keyType
+                                - signerName
+                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -3000,7 +3217,6 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-
@@ -3567,7 +3783,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3582,7 +3797,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3748,7 +3962,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -3763,7 +3976,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -3856,8 +4068,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -3926,7 +4138,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3941,7 +4152,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4107,7 +4317,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -4122,7 +4331,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -4218,6 +4426,13 @@ spec:
               authentication:
                 description: (Optional) Dragonfly Authentication mechanism
                 properties:
+                  autoCreatePasswordSecret:
+                    description: |-
+                      (Optional) When enabled, the operator auto-creates the password Secret.
+                      If passwordFromSecret is omitted, the Secret name defaults to <cluster-name>-password
+                      and the key defaults to "password". The generated Secret is retained if this is
+                      later disabled and is garbage-collected when the Dragonfly resource is deleted.
+                    type: boolean
                   clientCaCertSecret:
                     description: |-
                       (Optional) If specified, the Dragonfly instance will check if the
@@ -4340,7 +4555,6 @@ spec:
                       procMount denotes the type of proc mount to use for the containers.
                       The default value is Default which uses the container runtime defaults for
                       readonly paths and masked paths.
-                      This requires the ProcMountType feature flag to be enabled.
                       Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
@@ -4522,7 +4736,9 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     value:
                       description: |-
@@ -4578,6 +4794,43 @@ spec:
                               type: string
                           required:
                           - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -4703,8 +4956,9 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -4760,6 +5014,43 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -4822,14 +5113,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                        will be reported as an event when the container is starting. When a key exists in multiple
+                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                        When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -4850,8 +5141,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -5114,6 +5406,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -5484,7 +5782,9 @@ spec:
                           type: integer
                       type: object
                     resizePolicy:
-                      description: Resources resize policy for the container.
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
                         description: ContainerResizePolicy represents resource resize
                           policy for the container.
@@ -5516,7 +5816,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This is an alpha field and requires enabling the
+                            This field depends on the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -5570,10 +5870,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This field may only be set for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
+                        This overrides the pod-level restart policy. When this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                        have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -5585,6 +5885,59 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
+                    restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit. The rules are evaluated in
+                        order. Once a rule matches a container exit condition, the remaining
+                        rules are ignored. If no rule matches the container exit condition,
+                        the Container-level restart policy determines the whether the container
+                        is restarted or not. Constraints on the rules:
+                        - At most 20 rules are allowed.
+                        - Rules can have the same action.
+                        - Identical rules are not forbidden in validations.
+                        When rules are specified, container MUST set RestartPolicy explicitly
+                        even it if matches the Pod's RestartPolicy.
+                      items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
+                        properties:
+                          action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied. The only possible value is "Restart" to restart the
+                              container.
+                            type: string
+                          exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
+                            properties:
+                              operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values. Possible values are:
+                                  - In: the requirement is satisfied if the container exit code is in the
+                                    set of specified values.
+                                  - NotIn: the requirement is satisfied if the container exit code is
+                                    not in the set of specified values.
+                                type: string
+                              values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                            - operator
+                            type: object
+                        required:
+                        - action
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -5660,7 +6013,6 @@ spec:
                             procMount denotes the type of proc mount to use for the containers.
                             The default value is Default which uses the container runtime defaults for
                             readonly paths and masked paths.
-                            This requires the ProcMountType feature flag to be enabled.
                             Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
@@ -6405,7 +6757,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This is an alpha field and requires enabling the
+                      This field depends on the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -6597,7 +6949,7 @@ spec:
                       resources:
                         description: |-
                           resources represents the minimum resources the volume should have.
-                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          Users are allowed to specify resource requirements
                           that are lower than previous value but must still be higher than capacity recorded in the
                           status field of the claim.
                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6684,15 +7036,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -6798,7 +7148,7 @@ spec:
                       resources:
                         description: |-
                           resources represents the minimum resources the volume should have.
-                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          Users are allowed to specify resource requirements
                           that are lower than previous value but must still be higher than capacity recorded in the
                           status field of the claim.
                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6885,15 +7235,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -6942,9 +7290,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-
@@ -7084,7 +7433,6 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -7095,7 +7443,6 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -131,8 +131,9 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -188,6 +189,43 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -250,14 +288,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                        will be reported as an event when the container is starting. When a key exists in multiple
+                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                        When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -278,8 +316,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -542,6 +581,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -912,7 +957,9 @@ spec:
                           type: integer
                       type: object
                     resizePolicy:
-                      description: Resources resize policy for the container.
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
                         description: ContainerResizePolicy represents resource resize
                           policy for the container.
@@ -944,7 +991,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This is an alpha field and requires enabling the
+                            This field depends on the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -998,10 +1045,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This field may only be set for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
+                        This overrides the pod-level restart policy. When this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                        have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -1013,6 +1060,59 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
+                    restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit. The rules are evaluated in
+                        order. Once a rule matches a container exit condition, the remaining
+                        rules are ignored. If no rule matches the container exit condition,
+                        the Container-level restart policy determines the whether the container
+                        is restarted or not. Constraints on the rules:
+                        - At most 20 rules are allowed.
+                        - Rules can have the same action.
+                        - Identical rules are not forbidden in validations.
+                        When rules are specified, container MUST set RestartPolicy explicitly
+                        even it if matches the Pod's RestartPolicy.
+                      items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
+                        properties:
+                          action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied. The only possible value is "Restart" to restart the
+                              container.
+                            type: string
+                          exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
+                            properties:
+                              operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values. Possible values are:
+                                  - In: the requirement is satisfied if the container exit code is in the
+                                    set of specified values.
+                                  - NotIn: the requirement is satisfied if the container exit code is
+                                    not in the set of specified values.
+                                type: string
+                              values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                            - operator
+                            type: object
+                        required:
+                        - action
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -1088,7 +1188,6 @@ spec:
                             procMount denotes the type of proc mount to use for the containers.
                             The default value is Default which uses the container runtime defaults for
                             readonly paths and masked paths.
-                            This requires the ProcMountType feature flag to be enabled.
                             Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
@@ -2097,7 +2196,7 @@ spec:
                                 resources:
                                   description: |-
                                     resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    Users are allowed to specify resource requirements
                                     that are lower than previous value but must still be higher than capacity recorded in the
                                     status field of the claim.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -2185,15 +2284,13 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
+                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                    this field can be reset to its previous value (including nil) to cancel the modification.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -2375,12 +2472,10 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
                           type: string
                         path:
                           description: |-
@@ -2433,8 +2528,8 @@ spec:
                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                        The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        The volume will be mounted read-only (ro).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:
@@ -2459,7 +2554,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -2605,8 +2700,7 @@ spec:
                       description: |-
                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                        is on.
+                        are redirected to the pxd.portworx.com CSI driver.
                       properties:
                         fsType:
                           description: |-
@@ -2879,6 +2973,129 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
+                              podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or server.
+
+                                  Kubelet generates a private key and uses it to send a
+                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                  request and issues a certificate chain, Kubelet writes the key and
+                                  certificate chain to the pod filesystem.  The pod does not start until
+                                  certificates have been issued for each podCertificate projected volume
+                                  source in its spec.
+
+                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                  timestamp.
+
+                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                  field, or separate files, indicated by the keyPath and
+                                  certificateChainPath fields.
+
+                                  The credential bundle is a single file in PEM format.  The first PEM
+                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                  entries are the certificate chain issued by the signer (typically,
+                                  signers will return their certificate chain in leaf-to-root order).
+
+                                  Prefer using the credential bundle format, since your application code
+                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                  your application must make two separate file reads. If these coincide
+                                  with a certificate rotation, it is possible that the private key and leaf
+                                  certificate you read may not correspond to each other.  Your application
+                                  will need to check for this condition, and re-read until they are
+                                  consistent.
+
+                                  The named signer controls chooses the format of the certificate it
+                                  issues; consult the signer implementation's documentation to learn how to
+                                  use the certificates it issues.
+                                properties:
+                                  certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  credentialBundlePath:
+                                    description: |-
+                                      Write the credential bundle at this path in the projected volume.
+
+                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                      key.
+
+                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                      certificate chain from the signer (leaf and any intermediates).
+
+                                      Using credentialBundlePath lets your Pod's application code make a single
+                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                      project them to separate files, your application code will need to
+                                      additionally check that the leaf certificate was issued to the key.
+                                    type: string
+                                  keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  keyType:
+                                    description: |-
+                                      The type of keypair Kubelet will generate for the pod.
+
+                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                      "ECDSAP521", and "ED25519".
+                                    type: string
+                                  maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
+
+                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                      generates for this projection.
+
+                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                      value is 7862400 (91 days).
+
+                                      The signer implementation is then free to issue a certificate with any
+                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                      longer than 24 hours.
+                                    format: int32
+                                    type: integer
+                                  signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
+                                    type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                      metadata in any way.
+
+                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                      Entries are subject to the same validation as object metadata annotations,
+                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                      are placed on values, except an overall size limitation on the entire field.
+
+                                      Signers should document the keys and values they support. Signers should
+                                      deny requests that contain keys they do not recognize.
+                                    type: object
+                                required:
+                                - keyType
+                                - signerName
+                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -3013,7 +3230,6 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-
@@ -3580,7 +3796,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3595,7 +3810,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3761,7 +3975,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -3776,7 +3989,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -3869,8 +4081,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -3939,7 +4151,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3954,7 +4165,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4120,7 +4330,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -4135,7 +4344,6 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -4231,6 +4439,13 @@ spec:
               authentication:
                 description: (Optional) Dragonfly Authentication mechanism
                 properties:
+                  autoCreatePasswordSecret:
+                    description: |-
+                      (Optional) When enabled, the operator auto-creates the password Secret.
+                      If passwordFromSecret is omitted, the Secret name defaults to <cluster-name>-password
+                      and the key defaults to "password". The generated Secret is retained if this is
+                      later disabled and is garbage-collected when the Dragonfly resource is deleted.
+                    type: boolean
                   clientCaCertSecret:
                     description: |-
                       (Optional) If specified, the Dragonfly instance will check if the
@@ -4353,7 +4568,6 @@ spec:
                       procMount denotes the type of proc mount to use for the containers.
                       The default value is Default which uses the container runtime defaults for
                       readonly paths and masked paths.
-                      This requires the ProcMountType feature flag to be enabled.
                       Note that this field cannot be set when spec.os.name is windows.
                     type: string
                   readOnlyRootFilesystem:
@@ -4535,7 +4749,9 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     value:
                       description: |-
@@ -4591,6 +4807,43 @@ spec:
                               type: string
                           required:
                           - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -4716,8 +4969,9 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -4773,6 +5027,43 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -4835,14 +5126,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                        will be reported as an event when the container is starting. When a key exists in multiple
+                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                        When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -4863,8 +5154,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -5127,6 +5419,12 @@ spec:
                               - port
                               type: object
                           type: object
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -5497,7 +5795,9 @@ spec:
                           type: integer
                       type: object
                     resizePolicy:
-                      description: Resources resize policy for the container.
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
                         description: ContainerResizePolicy represents resource resize
                           policy for the container.
@@ -5529,7 +5829,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This is an alpha field and requires enabling the
+                            This field depends on the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -5583,10 +5883,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This field may only be set for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
+                        This overrides the pod-level restart policy. When this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                        have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -5598,6 +5898,59 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
+                    restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit. The rules are evaluated in
+                        order. Once a rule matches a container exit condition, the remaining
+                        rules are ignored. If no rule matches the container exit condition,
+                        the Container-level restart policy determines the whether the container
+                        is restarted or not. Constraints on the rules:
+                        - At most 20 rules are allowed.
+                        - Rules can have the same action.
+                        - Identical rules are not forbidden in validations.
+                        When rules are specified, container MUST set RestartPolicy explicitly
+                        even it if matches the Pod's RestartPolicy.
+                      items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
+                        properties:
+                          action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied. The only possible value is "Restart" to restart the
+                              container.
+                            type: string
+                          exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
+                            properties:
+                              operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values. Possible values are:
+                                  - In: the requirement is satisfied if the container exit code is in the
+                                    set of specified values.
+                                  - NotIn: the requirement is satisfied if the container exit code is
+                                    not in the set of specified values.
+                                type: string
+                              values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                            - operator
+                            type: object
+                        required:
+                        - action
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -5673,7 +6026,6 @@ spec:
                             procMount denotes the type of proc mount to use for the containers.
                             The default value is Default which uses the container runtime defaults for
                             readonly paths and masked paths.
-                            This requires the ProcMountType feature flag to be enabled.
                             Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
@@ -6418,7 +6770,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This is an alpha field and requires enabling the
+                      This field depends on the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -6610,7 +6962,7 @@ spec:
                       resources:
                         description: |-
                           resources represents the minimum resources the volume should have.
-                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          Users are allowed to specify resource requirements
                           that are lower than previous value but must still be higher than capacity recorded in the
                           status field of the claim.
                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6697,15 +7049,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -6811,7 +7161,7 @@ spec:
                       resources:
                         description: |-
                           resources represents the minimum resources the volume should have.
-                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          Users are allowed to specify resource requirements
                           that are lower than previous value but must still be higher than capacity recorded in the
                           status field of the claim.
                           More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6898,15 +7248,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -6955,9 +7303,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-
@@ -7097,7 +7446,6 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -7108,7 +7456,6 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
-                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-
@@ -7241,6 +7588,7 @@ rules:
   resources:
   - configmaps
   - pods
+  - secrets
   - services
   verbs:
   - create
@@ -7522,6 +7870,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
+        - --cluster-domain=cluster.local
         command:
         - /manager
         env:


### PR DESCRIPTION
Opt-in functionality to generate a secret with credentials and connection details for the cluster, if the secret is deleted/update the cluster will be updated too.
The functionality was inspired by the cnpg operator.
This cover the request of @laurivosandi in https://github.com/dragonflydb/dragonfly-operator/issues/50#issuecomment-1598669833