### PR TITLE
fix(controller): wait for the demoted pod to leave the service before disconnecting

### DIFF
--- a/charts/dragonfly-operator/templates/clusterroles.yaml
+++ b/charts/dragonfly-operator/templates/clusterroles.yaml
@@ -96,6 +96,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - dragonflydb.io
     resources:
       - dragonflies

--- a/charts/dragonfly-operator/templates/roles.yaml
+++ b/charts/dragonfly-operator/templates/roles.yaml
@@ -139,6 +139,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - dragonflydb.io
     resources:
       - dragonflies

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - dragonflydb.io
   resources:
   - dragonflies

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -478,6 +478,12 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 		return fmt.Errorf("failed to determine the current role of the instance: %w", err)
 	}
 
+	if wasMaster {
+		if err := dfi.setPendingClientDisconnect(ctx, pod, true); err != nil {
+			return fmt.Errorf("could not mark pod for client disconnect: %w", err)
+		}
+	}
+
 	// Sanitize masterIp in case ipv6
 	masterIp = sanitizeIp(masterIp)
 
@@ -518,7 +524,16 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 
 	if wasMaster {
 		// Prevent clients from sending commands to this old master
-		dfi.disconnectClients(ctx, redisClient, pod)
+		if err := dfi.disconnectClients(ctx, pod); err != nil {
+			dfi.log.Error(err, "failed to disconnect clients, will retry", "pod", pod.Name)
+			// Returning an error here would abort the caller's loop over the remaining pods.
+			// The annotation stays set, the next reconcile retries.
+			return nil
+		}
+
+		if err := dfi.setPendingClientDisconnect(ctx, pod, false); err != nil {
+			return fmt.Errorf("could not clear the client disconnect marker: %w", err)
+		}
 	}
 
 	return nil
@@ -557,6 +572,7 @@ func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Po
 		pod.Annotations = make(map[string]string)
 	}
 	pod.Annotations[resources.MasterIpAnnotationKey] = masterIp
+	delete(pod.Annotations, resources.PendingClientDisconnectAnnotationKey)
 
 	if err := dfi.client.Patch(ctx, pod, patch); err != nil {
 		return err
@@ -566,44 +582,38 @@ func (dfi *DragonflyInstance) replicaOfNoOne(ctx context.Context, pod *corev1.Po
 }
 
 // disconnectClients disconnects all non-replication clients from a pod.
-func (dfi *DragonflyInstance) disconnectClients(ctx context.Context, redisClient *redis.Client, pod *corev1.Pod) {
-	dfi.log.Info("disconnecting clients from replica", "pod", pod.Name)
-	clientList, err := redisClient.ClientList(ctx).Result()
+func (dfi *DragonflyInstance) disconnectClients(ctx context.Context, pod *corev1.Pod) error {
+	if pod.Status.PodIP == "" {
+		return fmt.Errorf("pod %s has no IP address", pod.Name)
+	}
+
+	addr := clientListenerAddress(pod.Status.PodIP)
+	dfi.log.Info("disconnecting clients", "pod", pod.Name, "addr", addr)
+
+	killed, err := dfi.getRedisClient(pod.Status.PodIP).ClientKillByFilter(ctx, "LADDR", addr).Result()
 	if err != nil {
-		dfi.log.Error(err, "failed to get client list from replica", "pod", pod.Name)
-		return
+		return fmt.Errorf("failed to kill clients on %s: %w", addr, err)
 	}
 
-	clients := []string{}
-	for _, clientInfo := range strings.Split(clientList, "\n") {
-		if clientInfo == "" {
-			continue
-		}
-		// Example clientInfo: "id=2 addr=10.42.1.123:50342 ... name=..."
-		// Avoid killing replication clients, internal clients, or this connection
-		if strings.Contains(clientInfo, "addr=127.0.0.1") ||
-			strings.Contains(clientInfo, "addr=::1") ||
-			strings.Contains(clientInfo, "addr=[::1]") ||
-			strings.Contains(clientInfo, "name=repl_") ||
-			strings.Contains(clientInfo, "name=dragonfly-operator") {
-			continue
-		}
+	dfi.log.Info("disconnected clients", "pod", pod.Name, "clients", killed)
+	return nil
+}
 
-		parts := strings.Split(clientInfo, " ")
-		for _, part := range parts {
-			if strings.HasPrefix(part, "addr=") {
-				addr := strings.TrimPrefix(part, "addr=")
-				if _, err := redisClient.ClientKill(ctx, addr).Result(); err != nil {
-					// Log and continue, don't block for a single failed kill
-					dfi.log.Error(err, "failed to kill client", "addr", addr)
-				} else {
-					clients = append(clients, addr)
-				}
-				break
-			}
+// setPendingClientDisconnect adds or removes the annotation that carries an unfinished
+// client disconnect over to the next reconcile.
+func (dfi *DragonflyInstance) setPendingClientDisconnect(ctx context.Context, pod *corev1.Pod, pending bool) error {
+	patch := client.MergeFrom(pod.DeepCopy())
+
+	if pending {
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
 		}
+		pod.Annotations[resources.PendingClientDisconnectAnnotationKey] = "true"
+	} else {
+		delete(pod.Annotations, resources.PendingClientDisconnectAnnotationKey)
 	}
-	dfi.log.Info("killed clients", "pod", pod.Name, "clients", clients)
+
+	return dfi.client.Patch(ctx, pod, patch)
 }
 
 // hasMasterRole returns true if the given pod is a master based on the replication info.

--- a/internal/controller/dragonfly_instance.go
+++ b/internal/controller/dragonfly_instance.go
@@ -33,6 +33,7 @@ import (
 	"github.com/redis/go-redis/v9/maintnotifications"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -479,6 +480,7 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 	}
 
 	if wasMaster {
+		// Too early to disconnect: the master service still routes to this pod.
 		if err := dfi.setPendingClientDisconnect(ctx, pod, true); err != nil {
 			return fmt.Errorf("could not mark pod for client disconnect: %w", err)
 		}
@@ -522,21 +524,71 @@ func (dfi *DragonflyInstance) replicaOf(ctx context.Context, pod *corev1.Pod, ma
 		return fmt.Errorf("could not update replica metadata: %w", err)
 	}
 
-	if wasMaster {
-		// Prevent clients from sending commands to this old master
-		if err := dfi.disconnectClients(ctx, pod); err != nil {
-			dfi.log.Error(err, "failed to disconnect clients, will retry", "pod", pod.Name)
-			// Returning an error here would abort the caller's loop over the remaining pods.
-			// The annotation stays set, the next reconcile retries.
-			return nil
-		}
+	return nil
+}
 
-		if err := dfi.setPendingClientDisconnect(ctx, pod, false); err != nil {
-			return fmt.Errorf("could not clear the client disconnect marker: %w", err)
+// clientDisconnectTimeout stops a stalled EndpointSlice controller from blocking the disconnect.
+const clientDisconnectTimeout = 30 * time.Second
+
+// reconcileClientDisconnect disconnects a demoted pod's clients once it has left the
+// master service's endpoint slices.
+func (dfi *DragonflyInstance) reconcileClientDisconnect(ctx context.Context, pod *corev1.Pod) (ctrl.Result, error) {
+	demotedAt, pending := pendingClientDisconnectSince(pod)
+	if !pending {
+		return ctrl.Result{}, nil
+	}
+
+	if isMaster(pod) {
+		// Promoted again before the disconnect ran, so it is no longer owed.
+		return ctrl.Result{}, dfi.setPendingClientDisconnect(ctx, pod, false)
+	}
+
+	if pod.Status.PodIP == "" {
+		// The pod lost its address, so the connections went with it.
+		return ctrl.Result{}, dfi.setPendingClientDisconnect(ctx, pod, false)
+	}
+
+	inEndpoints, err := dfi.inMasterServiceEndpoints(ctx, pod)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if inEndpoints {
+		if waited := time.Since(demotedAt); waited < clientDisconnectTimeout {
+			dfi.log.Info("waiting for the demoted pod to leave the master service", "pod", pod.Name, "waited", waited)
+			return ctrl.Result{RequeueAfter: clientDisconnectTimeout - waited}, nil
+		}
+		dfi.log.Info("master service still lists the demoted pod, disconnecting clients anyway",
+			"pod", pod.Name, "timeout", clientDisconnectTimeout)
+	}
+
+	if err := dfi.disconnectClients(ctx, pod); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to disconnect the clients of demoted pod %s: %w", pod.Name, err)
+	}
+
+	return ctrl.Result{}, dfi.setPendingClientDisconnect(ctx, pod, false)
+}
+
+// inMasterServiceEndpoints reports whether the pod is still listed in the master
+// service's endpoint slices. Node data planes converge on their own after that.
+func (dfi *DragonflyInstance) inMasterServiceEndpoints(ctx context.Context, pod *corev1.Pod) (bool, error) {
+	var endpointSlices discoveryv1.EndpointSliceList
+	if err := dfi.client.List(ctx, &endpointSlices,
+		client.InNamespace(dfi.df.Namespace),
+		client.MatchingLabels{discoveryv1.LabelServiceName: resources.MasterServiceName(dfi.df)},
+	); err != nil {
+		return false, fmt.Errorf("failed to list the endpoint slices of the master service: %w", err)
+	}
+
+	for _, endpointSlice := range endpointSlices.Items {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if endpointTargetsPod(endpoint, pod) {
+				return true, nil
+			}
 		}
 	}
 
-	return nil
+	return false, nil
 }
 
 // replicaOfNoOne configures the pod as a master along while updating other pods to be replicas
@@ -608,7 +660,7 @@ func (dfi *DragonflyInstance) setPendingClientDisconnect(ctx context.Context, po
 		if pod.Annotations == nil {
 			pod.Annotations = make(map[string]string)
 		}
-		pod.Annotations[resources.PendingClientDisconnectAnnotationKey] = "true"
+		pod.Annotations[resources.PendingClientDisconnectAnnotationKey] = time.Now().UTC().Format(time.RFC3339)
 	} else {
 		delete(pod.Annotations, resources.PendingClientDisconnectAnnotationKey)
 	}

--- a/internal/controller/dragonfly_instance_demotion_test.go
+++ b/internal/controller/dragonfly_instance_demotion_test.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2023 DragonflyDB authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	dfv1alpha1 "github.com/dragonflydb/dragonfly-operator/api/v1alpha1"
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
+	"github.com/go-logr/logr"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	demotedPodIP = "10.42.0.7"
+	newMasterIP  = "10.42.0.8"
+)
+
+// A client reconnecting while the demoted pod is still an endpoint lands back on
+// the read-only instance, so demotion must not disconnect anyone yet.
+func TestReplicaOfDoesNotDisconnectClientsWhileStillInTheMasterService(t *testing.T) {
+	k8s := newStaleEndpointClient(buildDemotionFixture(t))
+	srv := startFakeDragonfly(t, k8s.podInEndpoints)
+
+	dfi := newDemotionInstance(k8s, srv.addr())
+	defer dfi.Close()
+
+	pod := getDemotionPod(t, k8s)
+	require.NoError(t, dfi.replicaOf(t.Context(), pod, newMasterIP))
+
+	assert.False(t, srv.killedWhileInEndpoints(),
+		"clients were killed while the demoted pod was still an endpoint of the master Service: "+
+			"a reconnect in that window resolves back to the read-only instance")
+}
+
+func getDemotionPod(t *testing.T, k8s client.Client) *corev1.Pod {
+	t.Helper()
+
+	pod := &corev1.Pod{}
+	require.NoError(t, k8s.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "df-0"}, pod))
+
+	return pod
+}
+
+// buildDemotionFixture returns a master pod that is the sole endpoint of its service.
+func buildDemotionFixture(t *testing.T) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, discoveryv1.AddToScheme(scheme))
+	require.NoError(t, dfv1alpha1.AddToScheme(scheme))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "df-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				resources.DragonflyNameLabelKey:     "df",
+				resources.KubernetesAppNameLabelKey: resources.KubernetesAppName,
+				resources.KubernetesPartOfLabelKey:  resources.KubernetesPartOf,
+				resources.RoleLabelKey:              resources.Master,
+			},
+		},
+		Status: corev1.PodStatus{PodIP: demotedPodIP},
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "df", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				resources.DragonflyNameLabelKey:     "df",
+				resources.KubernetesAppNameLabelKey: resources.KubernetesAppName,
+				resources.RoleLabelKey:              resources.Master,
+			},
+		},
+	}
+
+	ready := true
+	slice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "df-xk29p",
+			Namespace: "default",
+			Labels:    map[string]string{discoveryv1.LabelServiceName: "df"},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses:  []string{demotedPodIP},
+			Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+			TargetRef:  &corev1.ObjectReference{Kind: "Pod", Name: "df-0", Namespace: "default"},
+		}},
+	}
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, service, slice).Build()
+}
+
+func newDemotionInstance(k8s client.Client, redisAddr string) *DragonflyInstance {
+	return &DragonflyInstance{
+		df: &dfv1alpha1.Dragonfly{
+			ObjectMeta: metav1.ObjectMeta{Name: "df", Namespace: "default"},
+		},
+		client: k8s,
+		log:    logr.Discard(),
+		redisClients: map[string]*redis.Client{
+			demotedPodIP: redis.NewClient(&redis.Options{
+				ClientName:  resources.DragonflyOperatorName,
+				Addr:        redisAddr,
+				DialTimeout: 5 * time.Second,
+			}),
+		},
+	}
+}
+
+// staleEndpointClient models the lag of the EndpointSlice controller: only the
+// first read still shows the demoted pod.
+type staleEndpointClient struct {
+	client.Client
+
+	// neverConverges stands in for a stalled EndpointSlice controller.
+	neverConverges bool
+
+	mu    sync.Mutex
+	reads int
+}
+
+func newStaleEndpointClient(c client.Client) *staleEndpointClient {
+	return &staleEndpointClient{Client: c}
+}
+
+func (c *staleEndpointClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	slices, ok := list.(*discoveryv1.EndpointSliceList)
+	if !ok {
+		return c.Client.List(ctx, list, opts...)
+	}
+
+	if err := c.Client.List(ctx, slices, opts...); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.reads++
+	stale := c.neverConverges || c.reads == 1
+	c.mu.Unlock()
+
+	if !stale {
+		for i := range slices.Items {
+			slices.Items[i].Endpoints = nil
+		}
+	}
+	return nil
+}
+
+// podInEndpoints reports whether a reconnect would still land on the demoted pod.
+func (c *staleEndpointClient) podInEndpoints() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.neverConverges || c.reads < 2
+}
+
+// fakeDragonfly is a minimal RESP server that records when clients were killed.
+type fakeDragonfly struct {
+	listener net.Listener
+
+	podInEndpoints func() bool
+
+	mu sync.Mutex
+	// failDisconnect makes CLIENT KILL fail, as a timeout on a busy instance would.
+	failDisconnect bool
+	killed         bool
+	killedInEndp   bool
+	attempts       int
+}
+
+func startFakeDragonfly(t *testing.T, podInEndpoints func() bool) *fakeDragonfly {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &fakeDragonfly{listener: listener, podInEndpoints: podInEndpoints}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go srv.serve(conn)
+		}
+	}()
+
+	return srv
+}
+
+func (s *fakeDragonfly) addr() string { return s.listener.Addr().String() }
+
+func (s *fakeDragonfly) sawKill() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.killed
+}
+
+func (s *fakeDragonfly) killedWhileInEndpoints() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.killedInEndp
+}
+
+func (s *fakeDragonfly) disconnectAttempts() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attempts
+}
+
+func (s *fakeDragonfly) setFailDisconnect(fail bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failDisconnect = fail
+}
+
+// startDisconnect records the CLIENT KILL attempt and reports whether it succeeds.
+func (s *fakeDragonfly) startDisconnect() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.attempts++
+	return !s.failDisconnect
+}
+
+func (s *fakeDragonfly) recordKill() {
+	inEndpoints := s.podInEndpoints()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.killed = true
+	s.killedInEndp = s.killedInEndp || inEndpoints
+}
+
+func (s *fakeDragonfly) serve(conn net.Conn) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	for {
+		args, err := readRESPCommand(reader)
+		if err != nil {
+			return
+		}
+		if _, err := conn.Write(s.reply(args)); err != nil {
+			return
+		}
+	}
+}
+
+func (s *fakeDragonfly) reply(args []string) []byte {
+	cmd := strings.ToLower(args[0])
+	sub := ""
+	if len(args) > 1 {
+		sub = strings.ToLower(args[1])
+	}
+
+	switch {
+	case cmd == "hello":
+		// go-redis tolerates a redis error here and falls back to RESP2.
+		return []byte("-ERR unknown command 'HELLO'\r\n")
+	case cmd == "info":
+		return respBulk("# Replication\r\nrole:master\r\nconnected_slaves:1\r\n")
+	case cmd == "client" && sub == "kill":
+		if !s.startDisconnect() {
+			return []byte("-ERR simulated failure\r\n")
+		}
+		s.recordKill()
+		// Dragonfly answers with the number of killed connections.
+		return []byte(":1\r\n")
+	default:
+		return []byte("+OK\r\n")
+	}
+}
+
+func respBulk(payload string) []byte {
+	return []byte("$" + strconv.Itoa(len(payload)) + "\r\n" + payload + "\r\n")
+}
+
+func readRESPCommand(reader *bufio.Reader) ([]string, error) {
+	header, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	header = strings.TrimRight(header, "\r\n")
+	if !strings.HasPrefix(header, "*") {
+		return nil, fmt.Errorf("expected a RESP array, got %q", header)
+	}
+	count, err := strconv.Atoi(header[1:])
+	if err != nil || count < 1 {
+		return nil, fmt.Errorf("bad RESP array header %q", header)
+	}
+
+	args := make([]string, 0, count)
+	for range count {
+		lengthLine, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		length, err := strconv.Atoi(strings.TrimRight(lengthLine, "\r\n")[1:])
+		if err != nil {
+			return nil, fmt.Errorf("bad RESP bulk header %q", lengthLine)
+		}
+		buf := make([]byte, length+2)
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:length]))
+	}
+	return args, nil
+}

--- a/internal/controller/dragonfly_instance_pending_disconnect_test.go
+++ b/internal/controller/dragonfly_instance_pending_disconnect_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 DragonflyDB authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileClientDisconnectWaitsForTheServiceToConverge(t *testing.T) {
+	k8s := newStaleEndpointClient(buildDemotionFixture(t))
+	srv := startFakeDragonfly(t, k8s.podInEndpoints)
+
+	dfi := newDemotionInstance(k8s, srv.addr())
+	defer dfi.Close()
+
+	pod := getDemotionPod(t, k8s)
+	require.NoError(t, dfi.replicaOf(t.Context(), pod, newMasterIP))
+	require.Contains(t, pod.Annotations, resources.PendingClientDisconnectAnnotationKey,
+		"a demoted master must be marked as still owing its clients a disconnect")
+
+	result, err := dfi.reconcileClientDisconnect(t.Context(), pod)
+	require.NoError(t, err)
+	assert.False(t, srv.sawKill(), "the master service still routes to the pod, so nothing may be killed yet")
+	assert.Positive(t, result.RequeueAfter, "a stalled EndpointSlice controller must not leave the demotion unfinished")
+
+	result, err = dfi.reconcileClientDisconnect(t.Context(), pod)
+	require.NoError(t, err)
+	assert.True(t, srv.sawKill(), "the pod left the master service, so its clients must be disconnected")
+	assert.Zero(t, result.RequeueAfter)
+	assert.NotContains(t, pod.Annotations, resources.PendingClientDisconnectAnnotationKey)
+}
+
+func TestReconcileClientDisconnectFallsThroughOnTimeout(t *testing.T) {
+	k8s := newStaleEndpointClient(buildDemotionFixture(t))
+	k8s.neverConverges = true
+	srv := startFakeDragonfly(t, k8s.podInEndpoints)
+
+	dfi := newDemotionInstance(k8s, srv.addr())
+	defer dfi.Close()
+
+	pod := getDemotionPod(t, k8s)
+	require.NoError(t, dfi.replicaOf(t.Context(), pod, newMasterIP))
+
+	pod.Annotations[resources.PendingClientDisconnectAnnotationKey] =
+		time.Now().Add(-clientDisconnectTimeout - time.Second).UTC().Format(time.RFC3339)
+
+	result, err := dfi.reconcileClientDisconnect(t.Context(), pod)
+	require.NoError(t, err)
+	assert.True(t, srv.sawKill(), "the wait is bounded, so the disconnect must happen even without convergence")
+	assert.Zero(t, result.RequeueAfter)
+	assert.NotContains(t, pod.Annotations, resources.PendingClientDisconnectAnnotationKey)
+}
+
+func TestReconcileClientDisconnectClearsTheMarkerOnPromotion(t *testing.T) {
+	k8s := newStaleEndpointClient(buildDemotionFixture(t))
+	srv := startFakeDragonfly(t, k8s.podInEndpoints)
+
+	dfi := newDemotionInstance(k8s, srv.addr())
+	defer dfi.Close()
+
+	pod := getDemotionPod(t, k8s)
+	require.NoError(t, dfi.replicaOf(t.Context(), pod, newMasterIP))
+
+	// replTakeover promotes a pod without touching the marker.
+	pod.Labels[resources.RoleLabelKey] = resources.Master
+
+	result, err := dfi.reconcileClientDisconnect(t.Context(), pod)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+	assert.False(t, srv.sawKill(), "a pod serving as master must keep its clients")
+	assert.NotContains(t, pod.Annotations, resources.PendingClientDisconnectAnnotationKey,
+		"a stranded marker keeps the pod in the field index and wakes it on every endpoint event")
+}
+
+func TestReconcileClientDisconnectKeepsTheMarkerWhenTheDisconnectFails(t *testing.T) {
+	k8s := newStaleEndpointClient(buildDemotionFixture(t))
+	srv := startFakeDragonfly(t, k8s.podInEndpoints)
+	srv.setFailDisconnect(true)
+
+	dfi := newDemotionInstance(k8s, srv.addr())
+	defer dfi.Close()
+
+	pod := getDemotionPod(t, k8s)
+	require.NoError(t, dfi.replicaOf(t.Context(), pod, newMasterIP))
+
+	_, err := dfi.reconcileClientDisconnect(t.Context(), pod)
+	require.NoError(t, err)
+
+	_, err = dfi.reconcileClientDisconnect(t.Context(), pod)
+	require.Equal(t, 1, srv.disconnectAttempts(), "the pod left the service, so a disconnect must have been attempted")
+	require.Error(t, err, "a failed disconnect must surface so the reconcile is retried with backoff")
+	require.Contains(t, pod.Annotations, resources.PendingClientDisconnectAnnotationKey,
+		"clearing the marker after a failed disconnect loses the obligation for good")
+
+	srv.setFailDisconnect(false)
+
+	_, err = dfi.reconcileClientDisconnect(t.Context(), pod)
+	require.NoError(t, err)
+	assert.True(t, srv.sawKill(), "the retry must actually disconnect once the instance answers again")
+	assert.NotContains(t, pod.Annotations, resources.PendingClientDisconnectAnnotationKey)
+}

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -24,12 +24,16 @@ import (
 
 	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type DfPodLifeCycleReconciler struct {
@@ -39,6 +43,7 @@ type DfPodLifeCycleReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -71,15 +76,10 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	defer dfi.Close()
 
-	if needsClientDisconnect(&pod) {
-		if err := dfi.disconnectClients(ctx, &pod); err != nil {
-			log.Error(err, "failed to disconnect clients, will retry", "pod", pod.Name)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-
-		if err := dfi.setPendingClientDisconnect(ctx, &pod, false); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to clear the client disconnect marker: %w", err)
-		}
+	// Returning early only defers this pod's own reconcile; master election is
+	// driven by every pod's events, not just this one.
+	if result, err := dfi.reconcileClientDisconnect(ctx, &pod); !result.IsZero() || err != nil {
+		return result, err
 	}
 
 	podReady, readinessErr := dfi.isPodReady(ctx, &pod)
@@ -214,10 +214,29 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, nil
 }
 
+// pendingClientDisconnectIndex keeps the endpoint slice handler off a full pod scan.
+const pendingClientDisconnectIndex = "pendingClientDisconnect"
+
+func indexPendingClientDisconnect(obj client.Object) []string {
+	if _, pending := pendingClientDisconnectSince(obj.(*corev1.Pod)); !pending {
+		return nil
+	}
+
+	return []string{"true"}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *DfPodLifeCycleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{},
+		pendingClientDisconnectIndex, indexPendingClientDisconnect); err != nil {
+		return fmt.Errorf("failed to index pods pending a client disconnect: %w", err)
+	}
+
+	// This predicate reads pod labels, so it must stay scoped to the pod source
+	// rather than going back to WithEventFilter, which also covers the slices below.
 	return ctrl.NewControllerManagedBy(mgr).
-		WithEventFilter(
+		Named("DragonflyPodLifecycle").
+		For(&corev1.Pod{}, builder.WithPredicates(
 			predicate.Funcs{
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return e.ObjectNew.GetLabels()[resources.KubernetesAppNameLabelKey] == resources.KubernetesAppName
@@ -228,8 +247,30 @@ func (r *DfPodLifeCycleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				DeleteFunc: func(e event.DeleteEvent) bool {
 					return e.Object.GetLabels()[resources.KubernetesAppNameLabelKey] == resources.KubernetesAppName
 				},
-			}).
-		Named("DragonflyPodLifecycle").
-		For(&corev1.Pod{}).
+			})).
+		Watches(&discoveryv1.EndpointSlice{}, handler.EnqueueRequestsFromMapFunc(r.podsAwaitingClientDisconnect)).
 		Complete(r)
+}
+
+// podsAwaitingClientDisconnect enqueues the demoted pods of the namespace whose endpoints changed.
+func (r *DfPodLifeCycleReconciler) podsAwaitingClientDisconnect(ctx context.Context, endpointSlice client.Object) []reconcile.Request {
+	if _, ok := endpointSlice.GetLabels()[discoveryv1.LabelServiceName]; !ok {
+		return nil
+	}
+
+	var pods corev1.PodList
+	if err := r.Client.List(ctx, &pods,
+		client.InNamespace(endpointSlice.GetNamespace()),
+		client.MatchingFields{pendingClientDisconnectIndex: "true"},
+	); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list the pods pending a client disconnect")
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(pods.Items))
+	for i := range pods.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&pods.Items[i])})
+	}
+
+	return requests
 }

--- a/internal/controller/dragonfly_pod_lifecycle_controller.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller.go
@@ -71,6 +71,17 @@ func (r *DfPodLifeCycleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	defer dfi.Close()
 
+	if needsClientDisconnect(&pod) {
+		if err := dfi.disconnectClients(ctx, &pod); err != nil {
+			log.Error(err, "failed to disconnect clients, will retry", "pod", pod.Name)
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		if err := dfi.setPendingClientDisconnect(ctx, &pod, false); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to clear the client disconnect marker: %w", err)
+		}
+	}
+
 	podReady, readinessErr := dfi.isPodReady(ctx, &pod)
 	if readinessErr != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to verify pod readiness: %w", readinessErr)

--- a/internal/controller/dragonfly_pod_lifecycle_controller_test.go
+++ b/internal/controller/dragonfly_pod_lifecycle_controller_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 DragonflyDB authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dragonflydb/dragonfly-operator/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPodsAwaitingClientDisconnect(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, discoveryv1.AddToScheme(scheme))
+
+	pending := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "df-0",
+		Namespace: "default",
+		Annotations: map[string]string{
+			resources.PendingClientDisconnectAnnotationKey: time.Now().UTC().Format(time.RFC3339),
+		},
+	}}
+	settled := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "df-1", Namespace: "default"}}
+	elsewhere := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "df-0",
+		Namespace: "other",
+		Annotations: map[string]string{
+			resources.PendingClientDisconnectAnnotationKey: time.Now().UTC().Format(time.RFC3339),
+		},
+	}}
+
+	k8s := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pending, settled, elsewhere).
+		WithIndex(&corev1.Pod{}, pendingClientDisconnectIndex, indexPendingClientDisconnect).
+		Build()
+	r := &DfPodLifeCycleReconciler{Reconciler: Reconciler{Client: k8s, Scheme: scheme}}
+
+	slice := &discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+		Name:      "df-xk29p",
+		Namespace: "default",
+		Labels:    map[string]string{discoveryv1.LabelServiceName: "df"},
+	}}
+
+	requests := r.podsAwaitingClientDisconnect(t.Context(), slice)
+	require.Len(t, requests, 1, "only the demoted pod of that namespace may be enqueued")
+	assert.Equal(t, "df-0", requests[0].Name)
+	assert.Equal(t, "default", requests[0].Namespace)
+
+	orphan := &discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Name: "loose", Namespace: "default"}}
+	assert.Empty(t, r.podsAwaitingClientDisconnect(t.Context(), orphan),
+		"a slice that backs no service cannot tell us anything about the master service")
+}

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -20,12 +20,15 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -199,12 +202,28 @@ func clientListenerAddress(podIp string) string {
 	return sanitizeIp(podIp) + ":" + strconv.Itoa(resources.DragonflyPort)
 }
 
-func needsClientDisconnect(pod *corev1.Pod) bool {
-	if pod.Annotations[resources.PendingClientDisconnectAnnotationKey] != "true" {
-		return false
+// pendingClientDisconnectSince returns the demotion time; an unparsable value reads as long expired.
+func pendingClientDisconnectSince(pod *corev1.Pod) (time.Time, bool) {
+	demotedAt, ok := pod.Annotations[resources.PendingClientDisconnectAnnotationKey]
+	if !ok {
+		return time.Time{}, false
 	}
 
-	return !isMaster(pod)
+	parsed, err := time.Parse(time.RFC3339, demotedAt)
+	if err != nil {
+		return time.Time{}, true
+	}
+
+	return parsed, true
+}
+
+// endpointTargetsPod reports whether a service endpoint routes to the pod.
+func endpointTargetsPod(endpoint discoveryv1.Endpoint, pod *corev1.Pod) bool {
+	if ref := endpoint.TargetRef; ref != nil && ref.Kind == "Pod" {
+		return ref.Name == pod.Name
+	}
+
+	return slices.Contains(endpoint.Addresses, pod.Status.PodIP)
 }
 
 // getOrdinal returns the ordinal of the pod.

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -195,6 +195,18 @@ func sanitizeIp(masterIp string) string {
 	return strings.Trim(masterIp, "[]")
 }
 
+func clientListenerAddress(podIp string) string {
+	return sanitizeIp(podIp) + ":" + strconv.Itoa(resources.DragonflyPort)
+}
+
+func needsClientDisconnect(pod *corev1.Pod) bool {
+	if pod.Annotations[resources.PendingClientDisconnectAnnotationKey] != "true" {
+		return false
+	}
+
+	return !isMaster(pod)
+}
+
 // getOrdinal returns the ordinal of the pod.
 func getOrdinal(podName string) int {
 	parts := strings.Split(podName, "-")

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -155,3 +155,88 @@ func TestSelectMasterCandidate(t *testing.T) {
 		})
 	}
 }
+
+func TestClientListenerAddress(t *testing.T) {
+	tests := []struct {
+		name  string
+		podIp string
+		want  string
+	}{
+		{
+			name:  "ipv4",
+			podIp: "10.42.1.7",
+			want:  "10.42.1.7:6379",
+		},
+		{
+			name:  "ipv6",
+			podIp: "fd00::1",
+			want:  "fd00::1:6379",
+		},
+		{
+			name:  "bracketed ipv6",
+			podIp: "[fd00::1]",
+			want:  "fd00::1:6379",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientListenerAddress(tc.podIp); got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestNeedsClientDisconnect(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		labels      map[string]string
+		want        bool
+	}{
+		{
+			name: "no annotations",
+			want: false,
+		},
+		{
+			name:        "marked and demoted",
+			annotations: map[string]string{resources.PendingClientDisconnectAnnotationKey: "true"},
+			labels:      map[string]string{resources.RoleLabelKey: resources.Replica},
+			want:        true,
+		},
+		{
+			name:        "marked without a role label",
+			annotations: map[string]string{resources.PendingClientDisconnectAnnotationKey: "true"},
+			want:        true,
+		},
+		{
+			name:        "marked but promoted again",
+			annotations: map[string]string{resources.PendingClientDisconnectAnnotationKey: "true"},
+			labels:      map[string]string{resources.RoleLabelKey: resources.Master},
+			want:        false,
+		},
+		{
+			name:        "unrelated annotation",
+			annotations: map[string]string{resources.MasterIpAnnotationKey: "10.42.1.7"},
+			labels:      map[string]string{resources.RoleLabelKey: resources.Replica},
+			want:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "df-0",
+					Labels:      tc.labels,
+					Annotations: tc.annotations,
+				},
+			}
+
+			if got := needsClientDisconnect(&pod); got != tc.want {
+				t.Errorf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dragonflydb/dragonfly-operator/internal/resources"
 	corev1 "k8s.io/api/core/v1"
@@ -188,54 +189,45 @@ func TestClientListenerAddress(t *testing.T) {
 	}
 }
 
-func TestNeedsClientDisconnect(t *testing.T) {
+func TestPendingClientDisconnectSince(t *testing.T) {
 	tests := []struct {
 		name        string
 		annotations map[string]string
-		labels      map[string]string
-		want        bool
+		wantPending bool
+		wantExpired bool
 	}{
 		{
-			name: "no annotations",
-			want: false,
+			name:        "no annotation",
+			wantPending: false,
 		},
 		{
-			name:        "marked and demoted",
+			name:        "valid timestamp",
+			annotations: map[string]string{resources.PendingClientDisconnectAnnotationKey: time.Now().UTC().Format(time.RFC3339)},
+			wantPending: true,
+			wantExpired: false,
+		},
+		{
+			name:        "unparsable value",
 			annotations: map[string]string{resources.PendingClientDisconnectAnnotationKey: "true"},
-			labels:      map[string]string{resources.RoleLabelKey: resources.Replica},
-			want:        true,
-		},
-		{
-			name:        "marked without a role label",
-			annotations: map[string]string{resources.PendingClientDisconnectAnnotationKey: "true"},
-			want:        true,
-		},
-		{
-			name:        "marked but promoted again",
-			annotations: map[string]string{resources.PendingClientDisconnectAnnotationKey: "true"},
-			labels:      map[string]string{resources.RoleLabelKey: resources.Master},
-			want:        false,
-		},
-		{
-			name:        "unrelated annotation",
-			annotations: map[string]string{resources.MasterIpAnnotationKey: "10.42.1.7"},
-			labels:      map[string]string{resources.RoleLabelKey: resources.Replica},
-			want:        false,
+			wantPending: true,
+			wantExpired: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pod := corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "df-0",
-					Labels:      tc.labels,
-					Annotations: tc.annotations,
-				},
+			pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "df-0", Annotations: tc.annotations}}
+
+			demotedAt, pending := pendingClientDisconnectSince(&pod)
+			if pending != tc.wantPending {
+				t.Fatalf("expected pending %v, got %v", tc.wantPending, pending)
+			}
+			if !pending {
+				return
 			}
 
-			if got := needsClientDisconnect(&pod); got != tc.want {
-				t.Errorf("expected %v, got %v", tc.want, got)
+			if expired := time.Since(demotedAt) >= clientDisconnectTimeout; expired != tc.wantExpired {
+				t.Errorf("expected expired %v, got %v", tc.wantExpired, expired)
 			}
 		})
 	}

--- a/internal/resources/const.go
+++ b/internal/resources/const.go
@@ -89,6 +89,8 @@ const (
 
 	MasterIpAnnotationKey = "operator.dragonflydb.io/masterIP"
 
+	PendingClientDisconnectAnnotationKey = "operator.dragonflydb.io/pendingClientDisconnect"
+
 	RoleLabelKey = "role"
 
 	Master = "master"

--- a/internal/resources/const.go
+++ b/internal/resources/const.go
@@ -89,6 +89,7 @@ const (
 
 	MasterIpAnnotationKey = "operator.dragonflydb.io/masterIP"
 
+	// PendingClientDisconnectAnnotationKey holds the RFC3339 demotion time of a pod owing a disconnect.
 	PendingClientDisconnectAnnotationKey = "operator.dragonflydb.io/pendingClientDisconnect"
 
 	RoleLabelKey = "role"

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -126,6 +126,15 @@ func generateProbeConfigMap(df *resourcesv1.Dragonfly, name, key, script string)
 	}
 }
 
+// MasterServiceName returns the name of the service that selects the master pod.
+func MasterServiceName(df *resourcesv1.Dragonfly) string {
+	if df.Spec.ServiceSpec != nil && df.Spec.ServiceSpec.Name != "" {
+		return df.Spec.ServiceSpec.Name
+	}
+
+	return df.Name
+}
+
 // GenerateDragonflyResources returns the resources required for a Dragonfly
 // Instance
 func GenerateDragonflyResources(df *resourcesv1.Dragonfly, defaultDragonflyImage, operatorNamespace string) ([]client.Object, error) {
@@ -569,14 +578,9 @@ func GenerateDragonflyResources(df *resourcesv1.Dragonfly, defaultDragonflyImage
 
 	resources = append(resources, &statefulset)
 
-	serviceName := df.Name
-	if df.Spec.ServiceSpec != nil && df.Spec.ServiceSpec.Name != "" {
-		serviceName = df.Spec.ServiceSpec.Name
-	}
-
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
+			Name:      MasterServiceName(df),
 			Namespace: df.Namespace,
 			// Useful for automatically deleting the resources when the Dragonfly object is deleted
 			OwnerReferences: []metav1.OwnerReference{

--- a/manifests/dragonfly-operator.yaml
+++ b/manifests/dragonfly-operator.yaml
@@ -7278,6 +7278,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - dragonflydb.io
   resources:
   - dragonflies


### PR DESCRIPTION
Stacked on #575. Its commit is the first of the two here and is not part of this change; this diff shrinks to a single commit once #575 merges.

#575 makes the client disconnect durable, but it still fires immediately after the role label patch, while the pod is still listed in the master Service's endpoint slices, so a reconnecting client lands straight back on the read-only instance. This defers the disconnect until the pod has actually left those endpoint slices.

**Changes** (second commit only)

- Disconnect from an endpoint slice watch on the pod lifecycle controller, once the demoted pod has left the master Service's endpoint slices.
- Bound the wait at 30s and fall through to the disconnect, so a stalled EndpointSlice controller cannot leave a demotion unfinished.
- Carry the RFC3339 demotion time in the pending marker instead of `"true"`, since bounding the wait needs a deadline that survives an operator restart.
- Clear the marker when a marked pod is promoted again, which `REPLTAKEOVER` did not do.
- New RBAC: `discovery.k8s.io` `endpointslices` get/list/watch, in `config/rbac`, `manifests/` and both Helm role templates. Apply it together with the image, the watch cannot start without it.

**Notes**

- `TestReplicaOfDoesNotDisconnectClientsWhileStillInTheMasterService` fails against #575 alone and passes with the second commit.
- Node data planes converge separately from the operator's watch cache, so a reconnect inside the per-node propagation delay can still reach the demoted pod. That delay cannot be closed from the operator; what this removes is the larger window in front of it.
- Reproduction (php-fpm, 8 workers, phpredis persistent connections, 300 requests, failover injected at request 80): 221 failed writes before, 0 after.
- Unit tests pass; the e2e suite was not run locally.

Fixes #324
